### PR TITLE
fix: clear Ruff F541/F401 lint failures in governance examples and SDK client

### DIFF
--- a/examples/07_huggingface_governed_agent.py
+++ b/examples/07_huggingface_governed_agent.py
@@ -19,7 +19,6 @@ Without KERNELS: Agent could execute arbitrary code without authorization.
 With KERNELS: Code execution requires cryptographically signed permit.
 """
 
-from typing import Dict, Any
 import json
 
 # KERNELS imports
@@ -27,7 +26,6 @@ from kernels.common.types import KernelConfig, VirtualClock
 from kernels.variants.strict_kernel import StrictKernel
 from kernels.integrations.huggingface_adapter import (
     HuggingFaceAdapter,
-    PermitInjector,
 )
 from kernels.permits import PermitBuilder
 
@@ -53,7 +51,7 @@ def execute_python_code(code: str) -> str:
     In production, this would use exec() or subprocess.
     This is exactly the kind of tool that needs governance.
     """
-    print(f"\n🚨 EXECUTING CODE:")
+    print("\n🚨 EXECUTING CODE:")
     print(f"   {code}")
     print()
     return f"Code executed: {code}"
@@ -65,7 +63,7 @@ def access_filesystem(path: str, operation: str) -> str:
 
     Could read sensitive files, modify system files, etc.
     """
-    print(f"\n🚨 FILESYSTEM ACCESS:")
+    print("\n🚨 FILESYSTEM ACCESS:")
     print(f"   Path: {path}")
     print(f"   Operation: {operation}")
     print()
@@ -123,7 +121,7 @@ def main():
     adapter = HuggingFaceAdapter(kernel, actor="research-agent-v1")
 
     # Wrap tools with proper HF schemas
-    search_tool = adapter.wrap_tool(
+    adapter.wrap_tool(
         name="web_search",
         func=web_search,
         description="Search the web for information",
@@ -131,7 +129,7 @@ def main():
         output_type="string",
     )
 
-    document_tool = adapter.wrap_tool(
+    adapter.wrap_tool(
         name="read_document",
         func=read_document,
         description="Read a document from path",
@@ -179,7 +177,7 @@ def main():
         result = code_tool(code="import os; os.system('rm -rf /')")
         print(f"✗ ERROR: Should have been denied! Result: {result}")
     except Exception as e:
-        print(f"✓ CORRECTLY DENIED by kernel")
+        print("✓ CORRECTLY DENIED by kernel")
         print(f"  Error: {e}")
         print()
         print("This prevents unauthorized code execution!")
@@ -222,7 +220,7 @@ def main():
         permit_token=code_permit,
     )
 
-    print(f"✓ ALLOWED by kernel")
+    print("✓ ALLOWED by kernel")
     print(f"  Result: {result}")
     print()
 
@@ -262,7 +260,7 @@ def main():
         permit_token=fs_permit,
     )
 
-    print(f"✓ ALLOWED by kernel")
+    print("✓ ALLOWED by kernel")
     print(f"  Result: {result}")
     print()
 
@@ -275,7 +273,7 @@ def main():
 
     evidence = adapter.export_evidence()
 
-    print(f"✓ Audit trail exported:")
+    print("✓ Audit trail exported:")
     print(f"  Kernel: {evidence['kernel_id']}")
     print(f"  Total entries: {evidence['entry_count']}")
     print(f"  Root hash: {evidence['root_hash'][:16]}...")
@@ -320,7 +318,7 @@ def main():
         json.dump(evidence, f, indent=2)
 
     print()
-    print(f"Full audit trail saved to: /tmp/hf_agent_audit.json")
+    print("Full audit trail saved to: /tmp/hf_agent_audit.json")
     print()
 
 

--- a/examples/08_openclaw_governed_agent.py
+++ b/examples/08_openclaw_governed_agent.py
@@ -39,7 +39,6 @@ Usage:
     agent.run("Delete all my emails from last month")  # DENIED: MISSING_PERMIT
 """
 
-from typing import Dict, Any
 import json
 import os
 
@@ -65,7 +64,7 @@ def shell_execute(command: str) -> str:
     Without governance: "rm -rf /" could be executed by mistake.
     With KERNELS: Requires cryptographically signed permit.
     """
-    print(f"\n🚨 SHELL EXECUTION:")
+    print("\n🚨 SHELL EXECUTION:")
     print(f"   Command: {command}")
     print()
 
@@ -83,7 +82,7 @@ def email_delete(mailbox: str, filter_query: str) -> str:
     Without governance: Agent could delete important emails.
     With KERNELS: Requires permit with exact filter parameters.
     """
-    print(f"\n🚨 EMAIL DELETION:")
+    print("\n🚨 EMAIL DELETION:")
     print(f"   Mailbox: {mailbox}")
     print(f"   Filter: {filter_query}")
     print()
@@ -100,7 +99,7 @@ def calendar_create_event(title: str, start_time: str, attendees: str) -> str:
     Without governance: Agent could schedule meetings without confirmation.
     With KERNELS: Requires permit for each event creation.
     """
-    print(f"\n📅 CALENDAR EVENT:")
+    print("\n📅 CALENDAR EVENT:")
     print(f"   Title: {title}")
     print(f"   Start: {start_time}")
     print(f"   Attendees: {attendees}")
@@ -119,7 +118,7 @@ def web_browse(url: str, action: str = "read") -> str:
     With KERNELS: Write actions require permits.
     """
     if action in ["submit", "click", "purchase"]:
-        print(f"\n🚨 WEB ACTION:")
+        print("\n🚨 WEB ACTION:")
         print(f"   URL: {url}")
         print(f"   Action: {action}")
         print()
@@ -137,7 +136,7 @@ def slack_send_message(channel: str, message: str, mention_all: bool = False) ->
     With KERNELS: Mentions require permits.
     """
     if mention_all:
-        print(f"\n🚨 SLACK @CHANNEL:")
+        print("\n🚨 SLACK @CHANNEL:")
         print(f"   Channel: {channel}")
         print(f"   Message: {message}")
         print()
@@ -227,7 +226,7 @@ def main():
         raise_on_deny=True,
     )
 
-    governed_slack = adapter.create_wrapper(
+    adapter.create_wrapper(
         name="slack_send_message",
         func=slack_send_message,
         description="Send Slack message",
@@ -255,7 +254,7 @@ def main():
         result = governed_shell(command="rm -rf /tmp/cache")
         print(f"✗ ERROR: Should have been denied! Result: {result}")
     except Exception as e:
-        print(f"✓ CORRECTLY DENIED by kernel")
+        print("✓ CORRECTLY DENIED by kernel")
         print(f"  Error: {e}")
         print()
         print("This prevents the '60k GitHub stars' honeypot attack!")
@@ -278,7 +277,7 @@ def main():
         )
         print(f"✗ ERROR: Should have been denied! Result: {result}")
     except Exception as e:
-        print(f"✓ CORRECTLY DENIED by kernel")
+        print("✓ CORRECTLY DENIED by kernel")
         print(f"  Error: {e}")
         print()
         print("Prevents accidental data loss from AI misinterpretation!")
@@ -326,7 +325,7 @@ def main():
         permit_token=calendar_permit,
     )
 
-    print(f"✓ ALLOWED by kernel")
+    print("✓ ALLOWED by kernel")
     print(f"  Result: {result}")
     print()
 
@@ -367,7 +366,7 @@ def main():
         permit_token=web_permit,
     )
 
-    print(f"✓ ALLOWED by kernel")
+    print("✓ ALLOWED by kernel")
     print(f"  Result: {result}")
     print()
 
@@ -380,7 +379,7 @@ def main():
 
     evidence = adapter.export_evidence()
 
-    print(f"✓ Audit trail exported:")
+    print("✓ Audit trail exported:")
     print(f"  Kernel: {evidence['kernel_id']}")
     print(f"  Total entries: {evidence['entry_count']}")
     print(f"  Root hash: {evidence['root_hash'][:16]}...")
@@ -439,7 +438,7 @@ def main():
         json.dump(evidence, f, indent=2)
 
     print()
-    print(f"Full audit trail saved to: /tmp/openclaw_audit.json")
+    print("Full audit trail saved to: /tmp/openclaw_audit.json")
     print()
 
 

--- a/examples/09_crewai_multiagent_governance.py
+++ b/examples/09_crewai_multiagent_governance.py
@@ -41,7 +41,6 @@ Usage:
     python examples/09_crewai_multiagent_governance.py
 """
 
-from typing import Dict, Any
 import json
 import os
 
@@ -58,7 +57,7 @@ from kernels.permits import PermitBuilder
 
 def web_search(query: str) -> str:
     """Search the web (LOW RISK - read-only)."""
-    print(f"\n🔍 WEB SEARCH:")
+    print("\n🔍 WEB SEARCH:")
     print(f"   Query: {query}")
     print()
     return f"Search results for: {query}\n- Result 1\n- Result 2\n- Result 3"
@@ -66,7 +65,7 @@ def web_search(query: str) -> str:
 
 def read_file(path: str) -> str:
     """Read file from filesystem (LOW RISK - read-only)."""
-    print(f"\n📄 FILE READ:")
+    print("\n📄 FILE READ:")
     print(f"   Path: {path}")
     print()
     return f"Contents of {path}: [simulated file data]"
@@ -74,7 +73,7 @@ def read_file(path: str) -> str:
 
 def analyze_data(data: str, analysis_type: str) -> str:
     """Analyze data (MEDIUM RISK - computation only)."""
-    print(f"\n📊 DATA ANALYSIS:")
+    print("\n📊 DATA ANALYSIS:")
     print(f"   Type: {analysis_type}")
     print(f"   Data length: {len(data)} chars")
     print()
@@ -83,7 +82,7 @@ def analyze_data(data: str, analysis_type: str) -> str:
 
 def create_report(title: str, content: str) -> str:
     """Create report (MEDIUM RISK - internal only)."""
-    print(f"\n📝 REPORT CREATION:")
+    print("\n📝 REPORT CREATION:")
     print(f"   Title: {title}")
     print(f"   Length: {len(content)} chars")
     print()
@@ -92,7 +91,7 @@ def create_report(title: str, content: str) -> str:
 
 def write_file(path: str, content: str) -> str:
     """Write file to filesystem (HIGH RISK - persistent state change)."""
-    print(f"\n🚨 FILE WRITE:")
+    print("\n🚨 FILE WRITE:")
     print(f"   Path: {path}")
     print(f"   Size: {len(content)} bytes")
     print()
@@ -101,7 +100,7 @@ def write_file(path: str, content: str) -> str:
 
 def send_email(to: str, subject: str, body: str) -> str:
     """Send email (HIGH RISK - external communication)."""
-    print(f"\n🚨 EMAIL SEND:")
+    print("\n🚨 EMAIL SEND:")
     print(f"   To: {to}")
     print(f"   Subject: {subject}")
     print()
@@ -110,7 +109,7 @@ def send_email(to: str, subject: str, body: str) -> str:
 
 def publish_blog(title: str, content: str, publish: bool = False) -> str:
     """Publish blog post (CRITICAL RISK - public visibility)."""
-    print(f"\n🚨 BLOG PUBLISH:")
+    print("\n🚨 BLOG PUBLISH:")
     print(f"   Title: {title}")
     print(f"   Publish: {publish}")
     print()
@@ -185,7 +184,7 @@ def main():
     analyst_id = adapter.create_agent_identity("Analyst")
     publisher_id = adapter.create_agent_identity("Publisher")
 
-    print(f"✓ Agent identities created:")
+    print("✓ Agent identities created:")
     print(f"  - Researcher: {researcher_id}")
     print(f"  - Analyst: {analyst_id}")
     print(f"  - Publisher: {publisher_id}")
@@ -277,9 +276,9 @@ def main():
     )
 
     print("✓ Tools wrapped with governance:")
-    print(f"  Researcher: web_search [NO PERMIT], read_file [NO PERMIT]")
-    print(f"  Analyst: analyze_data [NO PERMIT], create_report [NO PERMIT]")
-    print(f"  Publisher: write_file [PERMIT REQUIRED], send_email [PERMIT REQUIRED], publish_blog [PERMIT REQUIRED]")
+    print("  Researcher: web_search [NO PERMIT], read_file [NO PERMIT]")
+    print("  Analyst: analyze_data [NO PERMIT], create_report [NO PERMIT]")
+    print("  Publisher: write_file [PERMIT REQUIRED], send_email [PERMIT REQUIRED], publish_blog [PERMIT REQUIRED]")
     print()
 
     # ========================================================================
@@ -292,14 +291,14 @@ def main():
     # Researcher searches web
     print("Researcher searches web...")
     result = researcher_search._run(query="AI governance best practices")
-    print(f"✓ ALLOWED (no permit needed)")
+    print("✓ ALLOWED (no permit needed)")
     print(f"  Result: {result[:50]}...")
     print()
 
     # Researcher reads file
     print("Researcher reads file...")
     result = researcher_read._run(path="/data/research/papers.txt")
-    print(f"✓ ALLOWED (no permit needed)")
+    print("✓ ALLOWED (no permit needed)")
     print(f"  Result: {result[:50]}...")
     print()
 
@@ -309,7 +308,7 @@ def main():
         data="[research data from web search]",
         analysis_type="sentiment analysis"
     )
-    print(f"✓ ALLOWED (no permit needed)")
+    print("✓ ALLOWED (no permit needed)")
     print(f"  Result: {result}")
     print()
 
@@ -319,7 +318,7 @@ def main():
         title="AI Governance Analysis",
         content="[analysis results]"
     )
-    print(f"✓ ALLOWED (no permit needed)")
+    print("✓ ALLOWED (no permit needed)")
     print(f"  Result: {result}")
     print()
 
@@ -339,7 +338,7 @@ def main():
         )
         print(f"✗ ERROR: Should have been denied! Result: {result}")
     except PermissionError as e:
-        print(f"✓ CORRECTLY DENIED by KERNELS")
+        print("✓ CORRECTLY DENIED by KERNELS")
         print(f"  Error: {e}")
         print()
         print("This prevents unauthorized file system modifications!")
@@ -369,7 +368,7 @@ def main():
         .build(keyring, "crew-operator-2026")
     )
 
-    print(f"✓ Permit issued:")
+    print("✓ Permit issued:")
     print(f"  Permit ID: {write_permit.permit_id[:16]}...")
     print(f"  Action: {write_permit.action}")
     print(f"  Subject: {write_permit.subject}")
@@ -381,7 +380,7 @@ def main():
         permit_token=write_permit,
     )
 
-    print(f"✓ ALLOWED by KERNELS")
+    print("✓ ALLOWED by KERNELS")
     print(f"  Result: {result}")
     print()
 
@@ -402,9 +401,9 @@ def main():
     )
 
     if can_delegate:
-        print(f"✗ ERROR: Delegation should be blocked!")
+        print("✗ ERROR: Delegation should be blocked!")
     else:
-        print(f"✓ DELEGATION BLOCKED")
+        print("✓ DELEGATION BLOCKED")
         print(f"  {researcher_id} cannot delegate to {publisher_id}")
         print(f"  Allowed targets: {delegation_matrix[researcher_id]}")
         print()
@@ -421,12 +420,12 @@ def main():
     )
 
     if can_delegate:
-        print(f"✓ DELEGATION ALLOWED")
+        print("✓ DELEGATION ALLOWED")
         print(f"  {researcher_id} can delegate to {analyst_id}")
-        print(f"  Valid delegation chain maintained")
+        print("  Valid delegation chain maintained")
         print()
     else:
-        print(f"✗ ERROR: This delegation should be allowed!")
+        print("✗ ERROR: This delegation should be allowed!")
         print()
 
     # ========================================================================
@@ -473,8 +472,8 @@ def main():
     )
 
     print("✓ Two permits issued:")
-    print(f"  1. send_email → subscribers@company.com")
-    print(f"  2. publish_blog → 'AI Governance Best Practices'")
+    print("  1. send_email → subscribers@company.com")
+    print("  2. publish_blog → 'AI Governance Best Practices'")
     print()
 
     # Execute with permits
@@ -508,7 +507,7 @@ def main():
 
     evidence = adapter.export_evidence()
 
-    print(f"✓ Audit trail exported:")
+    print("✓ Audit trail exported:")
     print(f"  Kernel: {evidence['kernel_id']}")
     print(f"  Total entries: {evidence['entry_count']}")
     print(f"  Root hash: {evidence['root_hash'][:16]}...")
@@ -579,7 +578,7 @@ def main():
         json.dump(evidence, f, indent=2)
 
     print()
-    print(f"Full audit trail saved to: /tmp/crewai_multiagent_audit.json")
+    print("Full audit trail saved to: /tmp/crewai_multiagent_audit.json")
     print()
 
 

--- a/examples/10_autogpt_autonomous_governance.py
+++ b/examples/10_autogpt_autonomous_governance.py
@@ -45,7 +45,6 @@ Usage:
     python examples/10_autogpt_autonomous_governance.py
 """
 
-from typing import Dict, Any
 import json
 import os
 
@@ -62,7 +61,7 @@ from kernels.permits import PermitBuilder
 
 def execute_shell(command: str) -> str:
     """Execute shell command (CRITICAL RISK)."""
-    print(f"\n🚨 SHELL EXECUTION:")
+    print("\n🚨 SHELL EXECUTION:")
     print(f"   Command: {command}")
     print()
     # In production: subprocess.run(command, shell=True, capture_output=True)
@@ -71,16 +70,16 @@ def execute_shell(command: str) -> str:
 
 def execute_python(code: str) -> str:
     """Execute Python code (HIGH RISK)."""
-    print(f"\n🚨 PYTHON EXECUTION:")
+    print("\n🚨 PYTHON EXECUTION:")
     print(f"   Code: {code[:50]}...")
     print()
     # In production: exec(code)
-    return f"Simulated execution of Python code"
+    return "Simulated execution of Python code"
 
 
 def write_file(path: str, content: str) -> str:
     """Write file to filesystem (HIGH RISK)."""
-    print(f"\n🚨 FILE WRITE:")
+    print("\n🚨 FILE WRITE:")
     print(f"   Path: {path}")
     print(f"   Size: {len(content)} bytes")
     print()
@@ -89,7 +88,7 @@ def write_file(path: str, content: str) -> str:
 
 def read_file(path: str) -> str:
     """Read file from filesystem (LOW RISK)."""
-    print(f"\n📄 FILE READ:")
+    print("\n📄 FILE READ:")
     print(f"   Path: {path}")
     print()
     return f"Contents of {path}: [simulated file data]"
@@ -97,7 +96,7 @@ def read_file(path: str) -> str:
 
 def browse_website(url: str) -> str:
     """Browse website (LOW RISK)."""
-    print(f"\n🌐 WEB BROWSE:")
+    print("\n🌐 WEB BROWSE:")
     print(f"   URL: {url}")
     print()
     return f"Content from {url}: [simulated web data]"
@@ -105,7 +104,7 @@ def browse_website(url: str) -> str:
 
 def send_email(to: str, subject: str, body: str) -> str:
     """Send email (MEDIUM-HIGH RISK)."""
-    print(f"\n📧 EMAIL SEND:")
+    print("\n📧 EMAIL SEND:")
     print(f"   To: {to}")
     print(f"   Subject: {subject}")
     print()
@@ -114,7 +113,7 @@ def send_email(to: str, subject: str, body: str) -> str:
 
 def make_api_call(endpoint: str, method: str = "GET", data: str = "") -> str:
     """Make API call (MEDIUM RISK)."""
-    print(f"\n🔌 API CALL:")
+    print("\n🔌 API CALL:")
     print(f"   Endpoint: {endpoint}")
     print(f"   Method: {method}")
     print()
@@ -123,7 +122,7 @@ def make_api_call(endpoint: str, method: str = "GET", data: str = "") -> str:
 
 def delete_file(path: str) -> str:
     """Delete file (HIGH RISK)."""
-    print(f"\n🚨 FILE DELETE:")
+    print("\n🚨 FILE DELETE:")
     print(f"   Path: {path}")
     print()
     return f"File deleted: {path}"
@@ -219,7 +218,7 @@ def main():
         risk_score=1.0,
     )
 
-    governed_python = adapter.wrap_command(
+    adapter.wrap_command(
         "execute_python",
         execute_python,
         "Execute Python code",
@@ -233,7 +232,7 @@ def main():
         risk_score=0.8,
     )
 
-    governed_delete = adapter.wrap_command(
+    adapter.wrap_command(
         "delete_file",
         delete_file,
         "Delete file",
@@ -241,14 +240,14 @@ def main():
     )
 
     # Medium risk commands
-    governed_email = adapter.wrap_command(
+    adapter.wrap_command(
         "send_email",
         send_email,
         "Send email",
         risk_score=0.7,
     )
 
-    governed_api = adapter.wrap_command(
+    adapter.wrap_command(
         "make_api_call",
         make_api_call,
         "Make API call",
@@ -291,13 +290,13 @@ def main():
     # These should succeed because they're low risk
     print("Agent browses web for research...")
     result = governed_browse(url="https://example.com/ai-governance")
-    print(f"✓ ALLOWED (risk: 0.3)")
+    print("✓ ALLOWED (risk: 0.3)")
     print(f"  Result: {result[:50]}...")
     print()
 
     print("Agent reads existing research file...")
     result = governed_read(path="/data/research/notes.txt")
-    print(f"✓ ALLOWED (risk: 0.2)")
+    print("✓ ALLOWED (risk: 0.2)")
     print(f"  Result: {result[:50]}...")
     print()
 
@@ -314,7 +313,7 @@ def main():
         result = governed_shell(command="rm -rf /tmp/cache")
         print(f"✗ ERROR: Should have been denied! Result: {result}")
     except PermissionError as e:
-        print(f"✓ CORRECTLY DENIED by KERNELS")
+        print("✓ CORRECTLY DENIED by KERNELS")
         print(f"  Error: {e}")
         print()
         print("Kill-switch prevents unauthorized shell execution!")
@@ -344,9 +343,9 @@ def main():
         .build(keyring, "autogpt-operator-2026")
     )
 
-    print(f"✓ Permit issued for file write:")
+    print("✓ Permit issued for file write:")
     print(f"  Permit ID: {write_permit.permit_id[:16]}...")
-    print(f"  Path: /var/www/blog/ai-governance-article.md")
+    print("  Path: /var/www/blog/ai-governance-article.md")
     print()
 
     result = governed_write(
@@ -355,7 +354,7 @@ def main():
         permit_token=write_permit,
     )
 
-    print(f"✓ ALLOWED by KERNELS")
+    print("✓ ALLOWED by KERNELS")
     print(f"  Result: {result}")
     print()
 
@@ -395,7 +394,7 @@ def main():
         print("Executing command 99...")
         try:
             result = governed_browse(url="https://example.com/final-research")
-            print(f"✓ Command 99 executed successfully")
+            print("✓ Command 99 executed successfully")
             print()
         except RuntimeError as e:
             print(f"✗ Unexpected error: {e}")
@@ -404,7 +403,7 @@ def main():
         print("Executing command 100...")
         try:
             result = governed_read(path="/data/final-notes.txt")
-            print(f"✓ Command 100 executed successfully")
+            print("✓ Command 100 executed successfully")
             print()
         except RuntimeError as e:
             print(f"✗ Unexpected error: {e}")
@@ -414,9 +413,9 @@ def main():
         print("Attempting command 101 (should trigger kill-switch)...")
         try:
             result = governed_browse(url="https://example.com/post-limit")
-            print(f"✗ ERROR: Kill-switch should have activated!")
+            print("✗ ERROR: Kill-switch should have activated!")
         except RuntimeError as e:
-            print(f"✓ KILL-SWITCH ACTIVATED")
+            print("✓ KILL-SWITCH ACTIVATED")
             print(f"  Reason: {e}")
             print()
             print("Autonomous loop halted after reaching iteration limit!")
@@ -432,7 +431,7 @@ def main():
 
     evidence = adapter.export_evidence()
 
-    print(f"✓ Audit trail exported:")
+    print("✓ Audit trail exported:")
     print(f"  Kernel: {evidence['kernel_id']}")
     print(f"  Total entries: {evidence['entry_count']}")
     print(f"  Root hash: {evidence['root_hash'][:16]}...")
@@ -506,7 +505,7 @@ def main():
         json.dump(evidence, f, indent=2)
 
     print()
-    print(f"Full audit trail saved to: /tmp/autogpt_autonomous_audit.json")
+    print("Full audit trail saved to: /tmp/autogpt_autonomous_audit.json")
     print()
 
 

--- a/examples/11_langgraph_stateful_governance.py
+++ b/examples/11_langgraph_stateful_governance.py
@@ -45,7 +45,7 @@ Usage:
     python examples/11_langgraph_stateful_governance.py
 """
 
-from typing import Dict, Any, List
+from typing import Dict, Any
 import json
 import os
 
@@ -62,7 +62,7 @@ from kernels.permits import PermitBuilder
 
 def validate_order(state: Dict[str, Any]) -> Dict[str, Any]:
     """Validate order details (LOW RISK - no permits needed)."""
-    print(f"\n📋 VALIDATING ORDER:")
+    print("\n📋 VALIDATING ORDER:")
     print(f"   Order ID: {state.get('order_id')}")
     print(f"   Total: ${state.get('total_price', 0)}")
     print()
@@ -90,7 +90,7 @@ def validate_order(state: Dict[str, Any]) -> Dict[str, Any]:
 
 def process_payment(state: Dict[str, Any]) -> Dict[str, Any]:
     """Process payment (HIGH RISK - requires permit)."""
-    print(f"\n💳 PROCESSING PAYMENT:")
+    print("\n💳 PROCESSING PAYMENT:")
     print(f"   Amount: ${state.get('total_price', 0)}")
     print(f"   Payment method: {state.get('payment_method', 'unknown')}")
     print()
@@ -104,7 +104,7 @@ def process_payment(state: Dict[str, Any]) -> Dict[str, Any]:
 
 def update_inventory(state: Dict[str, Any]) -> Dict[str, Any]:
     """Update inventory (HIGH RISK - requires permit)."""
-    print(f"\n📦 UPDATING INVENTORY:")
+    print("\n📦 UPDATING INVENTORY:")
 
     items = state.get('items', [])
     inventory = state.get('inventory', {})
@@ -125,7 +125,7 @@ def update_inventory(state: Dict[str, Any]) -> Dict[str, Any]:
 
 def send_confirmation(state: Dict[str, Any]) -> Dict[str, Any]:
     """Send order confirmation email (MEDIUM RISK - requires permit)."""
-    print(f"\n📧 SENDING CONFIRMATION:")
+    print("\n📧 SENDING CONFIRMATION:")
     print(f"   To: {state.get('customer_email', 'unknown')}")
     print(f"   Order ID: {state.get('order_id')}")
     print()
@@ -137,7 +137,7 @@ def send_confirmation(state: Dict[str, Any]) -> Dict[str, Any]:
 
 def ship_order(state: Dict[str, Any]) -> Dict[str, Any]:
     """Ship order (HIGH RISK - requires permit)."""
-    print(f"\n🚚 SHIPPING ORDER:")
+    print("\n🚚 SHIPPING ORDER:")
     print(f"   Order ID: {state.get('order_id')}")
     print(f"   Address: {state.get('shipping_address', 'unknown')}")
     print()
@@ -352,9 +352,9 @@ def main():
 
     try:
         workflow_state = governed_payment(workflow_state)
-        print(f"✗ ERROR: Should have been denied!")
+        print("✗ ERROR: Should have been denied!")
     except PermissionError as e:
-        print(f"✓ CORRECTLY DENIED by KERNELS")
+        print("✓ CORRECTLY DENIED by KERNELS")
         print(f"  Error: {e}")
         print()
         print("Payment processing requires cryptographic permit!")
@@ -421,10 +421,10 @@ def main():
     )
 
     print("✓ Permits issued for workflow steps:")
-    print(f"  - process_payment")
-    print(f"  - update_inventory")
-    print(f"  - send_confirmation")
-    print(f"  - ship_order")
+    print("  - process_payment")
+    print("  - update_inventory")
+    print("  - send_confirmation")
+    print("  - ship_order")
     print()
 
     # Execute workflow with permits
@@ -467,10 +467,10 @@ def main():
     print()
 
     try:
-        violations = adapter.check_invariants(invalid_state)
-        print(f"✗ ERROR: Invariant check should have failed!")
+        adapter.check_invariants(invalid_state)
+        print("✗ ERROR: Invariant check should have failed!")
     except RuntimeError as e:
-        print(f"✓ INVARIANT VIOLATION DETECTED")
+        print("✓ INVARIANT VIOLATION DETECTED")
         print(f"  Error: {e}")
         print()
         print("Workflow halted due to invariant violation!")
@@ -504,7 +504,7 @@ def main():
 
     evidence = adapter.export_evidence()
 
-    print(f"✓ Audit trail exported:")
+    print("✓ Audit trail exported:")
     print(f"  Kernel: {evidence['kernel_id']}")
     print(f"  Total entries: {evidence['entry_count']}")
     print(f"  Root hash: {evidence['root_hash'][:16]}...")
@@ -577,7 +577,7 @@ def main():
         json.dump(evidence, f, indent=2)
 
     print()
-    print(f"Full audit trail saved to: /tmp/langgraph_workflow_audit.json")
+    print("Full audit trail saved to: /tmp/langgraph_workflow_audit.json")
     print()
 
 

--- a/kernels/sdk/client.py
+++ b/kernels/sdk/client.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 import json
 import urllib.request
 import urllib.error
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 import asyncio
 
-from kernels.common.types import Request, Receipt, ToolCall, Decision
+from kernels.common.types import Request, Receipt, Decision
 from kernels.common.errors import KernelError
 
 


### PR DESCRIPTION
### Motivation
- CI was failing due to Ruff lint errors: multiple `F541` (f-strings with no placeholders) and `F401` (unused imports) across example scripts and the SDK client.

### Description
- Converted static f-strings to plain string literals across the governance examples to remove `F541` violations in `examples/07_huggingface_governed_agent.py`, `examples/08_openclaw_governed_agent.py`, `examples/09_crewai_multiagent_governance.py`, `examples/10_autogpt_autonomous_governance.py`, and `examples/11_langgraph_stateful_governance.py`.
- Removed unused imports including `asdict` and `ToolCall` from `kernels/sdk/client.py` to resolve `F401` violations and cleaned up related typing imports in examples.
- Removed/avoided unused local assignments by calling wrapper/wrap methods without assigning to unused variables to clear remaining lint blockers while preserving runtime behavior.
- Files changed: `examples/07_huggingface_governed_agent.py`, `examples/08_openclaw_governed_agent.py`, `examples/09_crewai_multiagent_governance.py`, `examples/10_autogpt_autonomous_governance.py`, `examples/11_langgraph_stateful_governance.py`, `kernels/sdk/client.py`.

### Testing
- Ran `ruff check examples/07_huggingface_governed_agent.py examples/08_openclaw_governed_agent.py examples/09_crewai_multiagent_governance.py examples/10_autogpt_autonomous_governance.py examples/11_langgraph_stateful_governance.py kernels/sdk/client.py` and received `All checks passed!`.
- Applied `ruff --fix` and performed targeted edits to clear the remaining non-automatable issues; final `ruff check` passed on the updated set of files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dab9dec91c83269432d92ea86e6dc2)