### PR TITLE
ci: upgrade Codecov upload step to codecov-action@v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,10 @@ jobs:
 
       - name: Upload coverage report to Codecov
         if: matrix.python-version == '3.11'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
-          files: ./coverage.xml
-          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: Shards-foundation/kernels
 
       - name: Smoke checks
         run: ./scripts/smoke.sh


### PR DESCRIPTION
### Motivation
- Move CI coverage upload to the newer Codecov action and use explicit repo credentials instead of the previous `files`/`fail_ci_if_error` inputs.

### Description
- Modified `.github/workflows/ci.yml` to use `uses: codecov/codecov-action@v5` and replaced `files: ./coverage.xml` and `fail_ci_if_error: true` with `token: ${{ secrets.CODECOV_TOKEN }}` and `slug: Shards-foundation/kernels`, while keeping the existing `if: matrix.python-version == '3.11'` guard.

### Testing
- Ran `pytest -q tests/test_hashing.py`, which passed with `7 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dac0bd30a0832691448d367bf8beac)