### PR TITLE
fix(ci): upgrade GitHub Actions runtimes in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload coverage report to Codecov
         if: matrix.python-version == '3.11'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: Shards-foundation/kernels


### PR DESCRIPTION
### Motivation
- Upgrade the CI `quality` workflow to use newer GitHub Action major versions because older runtimes caused matrix jobs to fail on GitHub-hosted runners.

### Description
- Bumped action versions in `.github/workflows/ci.yml`: `actions/checkout@v4` → `actions/checkout@v5`, `actions/setup-python@v5` → `actions/setup-python@v6`, and `codecov/codecov-action@v5` → `codecov/codecov-action@v6`.

### Testing
- Ran `ruff check .`, `ruff format --check .`, `mypy kernels implementations`, `pytest` (136 tests passed), and `./scripts/smoke.sh`, all of which succeeded locally; `pytest --cov=...` could not be exercised due to missing `pytest-cov`, `python -m build` failed locally because the `build` module is not installed, and `bandit` was not available in the local environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dac903f0e88326ba68ff774c4d6aa1)