### PR TITLE
docs(report): separate observed facts from inferred judgments

### DIFF
--- a/FULL_TEST_REVIEW.md
+++ b/FULL_TEST_REVIEW.md
@@ -3,15 +3,17 @@
 Date: 2026-04-11
 Branch: `codex/full-test-review-2026-04-11`
 
-## Scope
-Executed repository quality gates to assess current code health:
+## Scope (Confidence: High)
+This report summarizes repository quality-gate outcomes for linting, formatting, type-checking, and tests.
 
 - Linting (`make lint`)
 - Formatting check (`make format-check`)
 - Static type checking (`make typecheck`)
 - Unit/integration test suite (`make test`)
 
-## Results Summary
+Evidence tag: **Observed from file `FULL_TEST_REVIEW.md`**.
+
+## Results Summary (Confidence: High)
 
 | Check | Status | Outcome |
 |---|---|---|
@@ -20,58 +22,123 @@ Executed repository quality gates to assess current code health:
 | `make typecheck` | ❌ Failed | Mypy reported 136 errors across 15 files. |
 | `make test` | ✅ Passed | 136/136 tests passed in 0.53s. |
 
-## Key Findings
+Evidence tag: **Observed from file `FULL_TEST_REVIEW.md`**.
 
-### 1) Linting failures are mostly hygiene-level and largely auto-fixable
-The Ruff failure set is dominated by:
+## Major Claims
 
-- `F401` unused imports across examples, adapters, SDK, and tests.
-- `F541` f-strings without placeholders.
-- `F841` assigned-but-unused variable(s).
-- `F402` import shadowing by loop variable.
+### 1) Linting failures are mostly hygiene-level and largely auto-fixable (Confidence: Medium)
 
-Impact: **Medium** (quality gate fails, but generally low functional risk).
+**Observed facts**
+- The lint check is marked failed with 58 issues and 55 auto-fixable.
+- The issue families listed are `F401`, `F541`, `F841`, and `F402`.
 
-### 2) Formatting drift is broad
-`ruff format --check` flagged 47 files for reformatting.
+Evidence tag: **Observed from file `FULL_TEST_REVIEW.md`**.
 
-Impact: **Low-Medium** (readability/consistency risk, CI gate blocker).
+**Inferred judgment**
+- Most lint issues are categorized as hygiene-level, with medium impact because they block quality gates but are usually low functional risk.
 
-### 3) Type-checking failures indicate API/type-model divergence
-Mypy reported 136 errors, with repeated patterns:
+Evidence tag: **Inferred from structure**.
 
-- Constructor/interface mismatches (unexpected kwargs, missing args).
-- Optional attribute access without guarding (`Item "None" has no attribute ...`).
-- Return-type incompatibilities (e.g., evidence objects vs expected dict).
-- Missing third-party stubs/imports for optional integrations.
-- Async support code calling outdated APIs/types.
+### 2) Formatting drift is broad (Confidence: High)
 
-Impact: **High** (static correctness and maintainability risk, CI gate blocker).
+**Observed facts**
+- Formatting check is marked failed.
+- `ruff format --check` is described as flagging 47 files.
 
-### 4) Runtime test suite remains green
-Despite static-check failures, pytest results are fully passing.
+Evidence tag: **Observed from file `FULL_TEST_REVIEW.md`**.
 
-Impact: **Positive signal** for current behavior under covered scenarios, but does not mitigate static type and lint gate failures.
+**Inferred judgment**
+- The drift is broad enough to be a CI blocker and primarily a readability/consistency concern.
 
-## Risk Assessment
+Evidence tag: **Inferred from structure**.
 
-- **Release readiness**: **Not ready** for strict CI pipelines that enforce lint/format/type gates.
-- **Runtime confidence**: **Moderate-High** based on passing tests.
-- **Maintainability confidence**: **Low-Moderate** until type/lint debt is reduced.
+### 3) Type-checking failures indicate API/type-model divergence (Confidence: Medium)
 
-## Recommended Remediation Order
+**Observed facts**
+- Type-checking is marked failed with 136 errors across 15 files.
+- Repeated error patterns listed: constructor/interface mismatches, nullable attribute access, return-type incompatibilities, missing optional stubs/imports, and async API/type mismatch patterns.
 
-1. **Auto-fix lint/format debt first**
-   - Run `ruff check --fix .`
-   - Run `ruff format .`
-2. **Address core type model mismatches**
+Evidence tag: **Observed from file `FULL_TEST_REVIEW.md`**.
+
+**Inferred judgment**
+- The error pattern distribution suggests divergence between interfaces and type models; this represents high static-correctness and maintainability risk.
+
+Evidence tag: **Inferred from structure**.
+
+### 4) Runtime test suite remains green (Confidence: High)
+
+**Observed facts**
+- Test check is marked passed with 136/136 tests in 0.53s.
+
+Evidence tag: **Observed from file `FULL_TEST_REVIEW.md`**.
+
+**Inferred judgment**
+- Current covered runtime behavior appears stable, but passing tests do not remove static gate risk.
+
+Evidence tag: **Inferred from structure**.
+
+## Risk Assessment (Confidence: Medium)
+
+**Observed facts**
+- Three static gates are failed in the summary table (lint, format, typecheck).
+- Runtime tests are passed.
+
+Evidence tag: **Observed from file `FULL_TEST_REVIEW.md`**.
+
+**Inferred judgments**
+- **Release readiness**: Not ready for strict CI pipelines enforcing all gates.
+- **Runtime confidence**: Moderate-High under current test coverage.
+- **Maintainability confidence**: Low-Moderate until lint/type debt is reduced.
+
+Evidence tag: **Inferred from structure**.
+
+## Recommended Remediation Order (Confidence: Medium)
+
+**Observed basis**
+- Failures are concentrated in lint/format/type gates.
+
+Evidence tag: **Observed from file `FULL_TEST_REVIEW.md`**.
+
+**Inferred prioritization**
+1. Auto-fix lint/format debt first.
+   - `ruff check --fix .`
+   - `ruff format .`
+2. Address core type-model mismatches.
    - Align `KernelRequest` / `KernelReceipt` usage across SDK and adapters.
    - Resolve nullable member access in `kernels/variants/base.py` and integration adapters.
-3. **Isolate optional integration typing**
-   - Gate or stub imports (`crewai`, `pydantic`, etc.) for local type-check reliability.
-4. **Re-run full CI sequence**
+3. Isolate optional integration typing.
+   - Gate or stub optional imports (`crewai`, `pydantic`, etc.) for local type-check reliability.
+4. Re-run full CI sequence.
    - `make ci`
 
-## Conclusion
+Evidence tag: **Inferred from structure**.
 
-The repository has a **passing runtime suite** but currently fails key static quality gates (lint, format, typecheck). Prioritizing auto-fixable Ruff issues and then type-model alignment should significantly improve CI stability.
+## Conclusion (Confidence: Medium)
+
+**Observed facts**
+- Runtime tests are passing.
+- Static quality gates are failing.
+
+Evidence tag: **Observed from file `FULL_TEST_REVIEW.md`**.
+
+**Inferred judgment**
+- Prioritizing auto-fixable Ruff issues followed by type-model alignment is likely to materially improve CI stability.
+
+Evidence tag: **Inferred from structure**.
+
+## Appendix A — Claim-to-Evidence Mapping
+
+| Claim ID | Claim (short) | Type | File path(s) | Inspection method |
+|---|---|---|---|---|
+| C1 | Lint failed with 58 issues, 55 auto-fixable | Observed | `FULL_TEST_REVIEW.md` | Manual document inspection (`sed -n`) |
+| C2 | Lint issue families are F401/F541/F841/F402 | Observed | `FULL_TEST_REVIEW.md` | Manual document inspection (`sed -n`) |
+| C3 | Lint impact is medium due to gate-blocking but low functional risk | Inferred | `FULL_TEST_REVIEW.md` | Structural interpretation of listed issue classes |
+| C4 | Format check failed with 47 files flagged | Observed | `FULL_TEST_REVIEW.md` | Manual document inspection (`sed -n`) |
+| C5 | Formatting drift is broad and CI-blocking | Inferred | `FULL_TEST_REVIEW.md` | Structural interpretation of reported count and gate status |
+| C6 | Typecheck failed with 136 errors across 15 files | Observed | `FULL_TEST_REVIEW.md` | Manual document inspection (`sed -n`) |
+| C7 | Error patterns indicate API/type-model divergence | Inferred | `FULL_TEST_REVIEW.md` | Pattern-based interpretation of listed mypy failures |
+| C8 | Tests passed 136/136 in 0.53s | Observed | `FULL_TEST_REVIEW.md` | Manual document inspection (`sed -n`) |
+| C9 | Runtime behavior appears stable for covered scenarios | Inferred | `FULL_TEST_REVIEW.md` | Interpretation from passing tests and explicit caveat |
+| C10 | Not release-ready for strict CI gates | Inferred | `FULL_TEST_REVIEW.md` | Synthesis of 3 failed static gates |
+| C11 | Prioritize lint/format autofix before type alignment | Inferred | `FULL_TEST_REVIEW.md` | Remediation ordering from issue fixability and gate impact |
+


### PR DESCRIPTION
### Motivation
- Clarify the Full Test and Review report by clearly distinguishing between direct observations and analyst inferences. 
- Make the report easier to audit by adding short evidence tags and per-section confidence labels. 
- Provide a traceable mapping from each claim to the inspected file(s) and the inspection method to support reviews.

### Description
- Refactored `FULL_TEST_REVIEW.md` to add explicit `Observed facts` and `Inferred judgment` blocks for each major claim. 
- Added per-section confidence labels and appended short evidence tags such as "Observed from file `FULL_TEST_REVIEW.md`" and "Inferred from structure". 
- Introduced `Appendix A` that maps each claim ID to file path(s) and the inspection method used. 
- Removed wording that used "executed" and made small structural/formatting edits to improve readability.

### Testing
- No automated tests were run for this documentation-only change. 
- The most recent automated test snapshot recorded in the report shows `make test` as passed with `136/136` tests (Observed from `FULL_TEST_REVIEW.md`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae91fe2f48326abe5ac4772185936)