### PR TITLE
docs(review): update potential improvements to reflect existing coverage tooling

### DIFF
--- a/FULL_TEST_REVIEW.md
+++ b/FULL_TEST_REVIEW.md
@@ -72,6 +72,23 @@ Impact: **Positive signal** for current behavior under covered scenarios, but do
 4. **Re-run full CI sequence**
    - `make ci`
 
+
+## Potential Improvements
+
+Coverage reporting is already integrated, so the next highest-value improvements are:
+
+1. **Enforce per-module minimum coverage targets**
+   - Define module-level floors (for example, higher thresholds for `kernels/` core logic and pragmatic thresholds for adapters/examples).
+   - Fail CI when a module drops below its minimum.
+
+2. **Add diff-coverage thresholds in CI**
+   - Require newly changed lines to meet a minimum diff-coverage target before merge.
+   - This keeps quality rising even when total-project coverage changes slowly.
+
+Existing implementation points that confirm baseline coverage integration:
+- `README.md` already exposes a Codecov coverage badge.
+- `.github/workflows/ci.yml` already uploads `coverage.xml` to Codecov.
+
 ## Conclusion
 
 The repository has a **passing runtime suite** but currently fails key static quality gates (lint, format, typecheck). Prioritizing auto-fixable Ruff issues and then type-model alignment should significantly improve CI stability.


### PR DESCRIPTION
### Motivation

- Update the review guidance to remove a redundant recommendation to add coverage reporting and instead propose higher-value next steps now that coverage tooling is present.

### Description

- Added a `Potential Improvements` section to `FULL_TEST_REVIEW.md` that replaces the suggestion to add coverage reporting with recommendations to enforce per-module minimum coverage targets and add diff-coverage thresholds in CI, and it references the existing `README.md` Codecov badge and the `.github/workflows/ci.yml` Codecov upload step.

### Testing

- Verified the change by grepping and inspecting files (`rg`, `nl`, `sed`) to confirm the new section and references, and committed the docs update; no unit tests were required for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae91e6d2083269857402e6437f537)