### PR TITLE
Docs: remove hard dates, canonicalize spec links, and tidy roadmap/compliance text

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,12 +161,12 @@ Outputs:
 
 | Document | Content |
 |----------|---------|
-| [spec/SPEC.md](spec/SPEC.md) | Normative requirements |
-| [spec/STATES.md](spec/STATES.md) | State machine + transitions |
-| [spec/JURISDICTION.md](spec/JURISDICTION.md) | Policy rules |
-| [spec/AUDIT.md](spec/AUDIT.md) | Ledger + hashing + evidence bundle |
-| [spec/ERROR_MODEL.md](spec/ERROR_MODEL.md) | Error taxonomy |
-| [spec/VARIANTS.md](spec/VARIANTS.md) | Posture variants |
+| [spec/SPEC.md](https://github.com/Shards-foundation/kernels/blob/main/spec/SPEC.md) | Normative requirements |
+| [spec/STATES.md](https://github.com/Shards-foundation/kernels/blob/main/spec/STATES.md) | State machine + transitions |
+| [spec/JURISDICTION.md](https://github.com/Shards-foundation/kernels/blob/main/spec/JURISDICTION.md) | Policy rules |
+| [spec/AUDIT.md](https://github.com/Shards-foundation/kernels/blob/main/spec/AUDIT.md) | Ledger + hashing + evidence bundle |
+| [spec/ERROR_MODEL.md](https://github.com/Shards-foundation/kernels/blob/main/spec/ERROR_MODEL.md) | Error taxonomy |
+| [spec/VARIANTS.md](https://github.com/Shards-foundation/kernels/blob/main/spec/VARIANTS.md) | Posture variants |
 
 **Architecture + Threat Model**:
 

--- a/docs/COMPLIANCE_MAPPING.md
+++ b/docs/COMPLIANCE_MAPPING.md
@@ -20,10 +20,10 @@ This document shows how these properties map to specific regulatory requirements
 ## Table of Contents
 
 1. [EU AI Act](#eu-ai-act)
-2. [ISO 42001 AI Management System](#iso-42001)
-3. [UK AI Safety Institute Guidance](#uk-aisi)
-4. [NIST AI Risk Management Framework](#nist-ai-rmf)
-5. [SOC 2 Type II Controls](#soc-2)
+2. [ISO 42001 AI Management System](#iso-42001-ai-management-system)
+3. [UK AI Safety Institute Guidance](#uk-ai-safety-institute-guidance)
+4. [NIST AI Risk Management Framework](#nist-ai-risk-management-framework)
+5. [SOC 2 Type II Controls](#soc-2-type-ii-controls)
 6. [Mapping Summary Table](#mapping-summary)
 
 ---

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -1,7 +1,7 @@
 # KERNELS Roadmap
 
 **Version:** 0.1.0  
-**Last Updated:** January 2025
+**Last Updated:** Capability progression (non-dated)
 
 ---
 
@@ -11,10 +11,10 @@ KERNELS becomes the standard control plane for governed AI agent execution, maki
 
 ---
 
-## Release Timeline
+## Capability Progression
 
 ```
-2025 Q1          2025 Q2          2025 Q3          2025 Q4
+Phase 1         Phase 2         Phase 3         Phase 4
     │                │                │                │
     ▼                ▼                ▼                ▼
 ┌────────┐      ┌────────┐      ┌────────┐      ┌────────┐
@@ -29,7 +29,7 @@ KERNELS becomes the standard control plane for governed AI agent execution, maki
 ## Phase 1: Foundation (v0.1.x) — CURRENT
 
 **Status:** ✅ Complete  
-**Timeline:** Q4 2024 - Q1 2025
+**Progression Slot:** Initial foundation capabilities
 
 ### Deliverables
 
@@ -58,7 +58,7 @@ KERNELS becomes the standard control plane for governed AI agent execution, maki
 ## Phase 2: Hardening (v0.2.x)
 
 **Status:** 🔄 In Progress  
-**Timeline:** Q1 2025
+**Progression Slot:** Security and reliability hardening
 
 ### Deliverables
 
@@ -75,19 +75,19 @@ KERNELS becomes the standard control plane for governed AI agent execution, maki
 
 ### Milestones
 
-| Milestone | Target Date | Criteria |
-|-----------|-------------|----------|
-| M2.1 Security audit complete | Feb 2025 | No critical findings |
-| M2.2 Permit tokens working | Feb 2025 | End-to-end flow |
-| M2.3 CI/CD operational | Mar 2025 | Auto-test on PR |
-| M2.4 v0.2.0 release | Mar 2025 | All P0 items done |
+| Milestone | Sequence | Criteria |
+|-----------|----------|----------|
+| M2.1 Security audit complete | First | No critical findings |
+| M2.2 Permit tokens working | Second | End-to-end flow |
+| M2.3 CI/CD operational | Third | Auto-test on PR |
+| M2.4 v0.2.0 release | Fourth | All P0 items done |
 
 ---
 
 ## Phase 3: Scale (v0.3.x)
 
 **Status:** 🔲 Planned  
-**Timeline:** Q2 2025
+**Progression Slot:** Scalability and distributed architecture
 
 ### Deliverables
 
@@ -122,7 +122,7 @@ Future (v0.3.x):
 ## Phase 4: Ecosystem (v0.4.x - v1.0.0)
 
 **Status:** 🔲 Planned  
-**Timeline:** Q3-Q4 2025
+**Progression Slot:** Ecosystem integrations and platform maturity
 
 ### Deliverables
 
@@ -149,7 +149,7 @@ Future (v0.3.x):
 
 ## v1.0.0 Release Criteria
 
-**Target:** Q4 2025
+**Target:** After Phase 4 criteria are satisfied
 
 ### Must Have
 
@@ -174,7 +174,7 @@ Future (v0.3.x):
 
 ## Long-Term Vision (v2.x+)
 
-### 2026 and Beyond
+### Long Horizon
 
 | Area | Vision |
 |------|--------|
@@ -207,10 +207,14 @@ Future (v0.3.x):
 
 ---
 
-## Changelog
+## Methodology
 
-| Date | Change |
+Timeline language is intentionally non-dated and ordered by capability progression to avoid unsupported calendar claims; dates are only retained when directly verifiable from commit metadata.
+
+## Revision Notes
+
+| Entry | Change |
 |------|--------|
-| Jan 2025 | Initial roadmap created |
-| Jan 2025 | Phase 1 marked complete |
-| Jan 2025 | Phase 2 started |
+| 1 | Initial roadmap created |
+| 2 | Phase 1 marked complete |
+| 3 | Phase 2 started |


### PR DESCRIPTION
### Motivation
- Remove explicit calendar dates and other time-based claims from the roadmap to avoid accidental commitments and keep the documentation evergreen. 
- Make spec links canonical so cross-repo references resolve reliably from rendered documentation. 
- Clarify wording and anchors in compliance and roadmap docs for consistency and better readability.

### Description
- Updated `README.md` to replace relative `spec/` links with full GitHub URLs to the repository spec files. 
- Revised `docs/COMPLIANCE_MAPPING.md` to normalize Table of Contents anchor text (e.g. expanded headings like `#iso-42001-ai-management-system`). 
- Reworked `docs/roadmap/ROADMAP.md` to remove dated timelines and replace them with non-dated "Capability Progression" language, adjusted phase/timeline labels, milestone sequencing, and replaced the dated changelog with a non-dated methodology and revision notes section.

### Testing
- No automated tests were run as these are documentation-only changes. 
- Documentation rendering was verified visually in a local preview to ensure links and headings resolve correctly. 
- No codepaths were modified, so no unit or integration tests were applicable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae9218ae48326ba2311d68104e352)