### PR TITLE
ci(coverage): enable branch coverage and align Codecov action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,11 @@ jobs:
         run: bandit -r kernels implementations -q
 
       - name: Run tests with coverage
-        run: pytest --cov=kernels --cov=implementations --cov-report=term-missing --cov-report=xml --cov-fail-under=80
+        run: pytest --cov=kernels --cov=implementations --cov-branch --cov-report=term-missing --cov-report=xml --cov-fail-under=80
 
       - name: Upload coverage report to Codecov
         if: matrix.python-version == '3.11'
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: Shards-foundation/kernels


### PR DESCRIPTION
### Motivation
- Enable branch coverage collection in CI by adding `--cov-branch` to the test run and align the Codecov GitHub Action version to the requested configuration.

### Description
- Modified `.github/workflows/ci.yml` to add `--cov-branch` to the `pytest` invocation and changed `uses: codecov/codecov-action@v6` to `uses: codecov/codecov-action@v5` while keeping `secrets.CODECOV_TOKEN` and the repository `slug` unchanged.

### Testing
- Attempted `pip install pytest pytest-cov` which failed due to package index/proxy restrictions, and running `pytest --cov=kernels --cov=implementations --cov-branch --cov-report=xml` also failed locally because `pytest-cov` was not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e96abe71208326a76f7c34dbbc6aa6)