### PR TITLE
Introduce KernelRuntime choke point, memory primitives, graph execution, and tests

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Documentation for understanding and integrating KERNELS.
 | Document | Purpose |
 |----------|---------|
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Component boundaries and data flows |
+| [architecture/KERNEL_STRATA.md](architecture/KERNEL_STRATA.md) | Taxonomy for memory/runtime/governance/multi-agent kernel layers |
 | [THREAT_MODEL.md](THREAT_MODEL.md) | Adversary model + mitigations |
 | [pipelines/HPC_CICD_ARCHITECTURE.md](pipelines/HPC_CICD_ARCHITECTURE.md) | Advanced CI/CD design for deterministic kernel infrastructure |
 | [FAQ.md](FAQ.md) | Usage clarifications and non-goals |

--- a/docs/architecture/KERNEL_STRATA.md
+++ b/docs/architecture/KERNEL_STRATA.md
@@ -1,0 +1,151 @@
+# Agent Kernel Strata, Current Gaps, and Re-Architecture Plan
+
+## Purpose
+
+This document disambiguates the overloaded term "agent kernel" into explicit
+strata and maps those strata to the current repository implementation.
+It also records the architectural gaps that must be closed for KERNELS to
+function as a full microkernel-style substrate rather than a governance-focused
+framework with a thin runtime.
+
+## Four Kernel Strata (Canonical Taxonomy)
+
+| Stratum | Responsibility | Typical primitives |
+|---|---|---|
+| **Memory Kernel** | Persistence lifecycle and retrieval semantics | working/episodic/semantic/procedural memory, TTL, confidence, provenance |
+| **Runtime Kernel** | Execution mediation between agent intent and tools | syscall interface, dispatcher, budget enforcement, retries, tracing |
+| **Governance Kernel** | Policy and permit enforcement | authorization, deny/allow decisions, jurisdiction rules, safety guardrails |
+| **Multi-Agent Kernel** | Agent-to-agent contracts and orchestration | capability schemas, registries, message protocols, coordination semantics |
+
+## Current Repository Mapping
+
+| Repository area | Primary stratum | Status |
+|---|---|---|
+| `kernels/jurisdiction/*`, `kernels/permits.py`, kernel variants | Governance | **Strong** |
+| `kernels/audit/*`, replay tests | Governance / verification | **Strong** |
+| `kernels/execution/*`, adapters under `kernels/integrations/*` | Runtime | **Partial** |
+| `kernels/state/*` | Control-flow state only | **Partial** |
+| Dedicated memory modules | Memory | **Missing** |
+| Dedicated multi-agent contracts/protocols | Multi-agent | **Missing** |
+
+## Structural Fractures (Second-Order)
+
+### 1) Runtime choke point is not explicit enough
+
+A strict kernel requires one authoritative execution path:
+
+`agent -> kernel syscall -> policy/budget/event/audit -> tool dispatch`
+
+Any direct `agent -> tool` path (including adapter shortcuts) weakens
+invariants and observability.
+
+### 2) Event model is implied but not first-class
+
+Replay quality depends on a versioned event schema and append-only event stream.
+Without this, replay can drift into best-effort behavior.
+
+### 3) Memory kernel is absent
+
+State machine + audit history are not substitutes for memory primitives.
+The system currently lacks explicit memory classes with lifecycle controls
+(TTL, confidence, provenance, mutation policy).
+
+### 4) Variant behavior risks fragmentation
+
+Variants should primarily be policy profiles, not alternate core logic paths.
+If core invariants vary by variant implementation, formal reasoning cost grows
+non-linearly.
+
+### 5) Resource model is under-specified
+
+Permits without token/time/cost accounting cannot enforce operational budgets
+or bound runaway execution behavior.
+
+## Mandatory Boundary Rules
+
+1. **All tool execution must cross a syscall boundary**.
+2. **Governance must execute on the hot path** (not post-hoc).
+3. **All executions must emit typed, versioned events**.
+4. **Replay inputs must be sufficient for deterministic verification**.
+5. **Memory types must be explicit and lifecycle-managed**.
+6. **Variants may tune policy thresholds, not bypass invariants**.
+
+## Minimum Event Spine (v1)
+
+- `task.started`
+- `task.completed`
+- `tool.called`
+- `tool.completed`
+- `policy.denied`
+- `error.raised`
+
+Each event should include: `event_id`, `event_type`, `schema_version`,
+`trace_id`, `timestamp`, `actor`, and deterministic payload fields.
+
+## Re-Architecture Plan (Not Patch-Level)
+
+### Phase 1: Establish kernel core choke point
+
+Create a core execution entrypoint that every adapter and workflow must use.
+
+Suggested layout:
+
+- `kernels/core/runtime.py`
+- `kernels/core/syscall.py`
+
+Core path responsibilities:
+
+1. Validate call contract
+2. Enforce permit + policy + budget
+3. Emit pre/post execution events
+4. Dispatch tool call
+5. Record audit ledger entry
+
+### Phase 2: Introduce event subsystem
+
+Suggested layout:
+
+- `kernels/events/schema.py`
+- `kernels/events/bus.py`
+- `kernels/events/store.py`
+
+Requirements:
+
+- versioned event schemas
+- append-only event storage semantics
+- subscription hooks for observability and streaming integrations
+
+### Phase 3: Add memory kernel
+
+Suggested layout:
+
+- `kernels/memory/working.py`
+- `kernels/memory/episodic.py`
+- `kernels/memory/semantic.py`
+- `kernels/memory/procedural.py`
+
+Minimum metadata per memory record:
+
+- `ttl`
+- `confidence`
+- `provenance`
+- `version`
+
+### Phase 4: Convert variants into policy profiles
+
+Preserve a single invariant core and load variant behavior via configuration
+presets instead of logic forks.
+
+### Phase 5: Add multi-agent contracts
+
+Introduce:
+
+- capability schema
+- agent registry
+- interaction protocol contract
+
+## Design Heuristic
+
+If a component does not enforce invariants or mediate interaction boundaries,
+it is framework/application logic and should not live in the authoritative
+kernel surface.

--- a/kernels/api.py
+++ b/kernels/api.py
@@ -42,6 +42,20 @@ from kernels.variants.dual_channel_kernel import DualChannelKernel
 # Tooling surface (stable)
 # -----------------------------------------------------------------------------
 from kernels.execution.tools import ToolRegistry
+from kernels.core.runtime import (
+    Artifact,
+    ArtifactRef,
+    ExecutionIdentity,
+    ExecutionContext,
+    GraphBudget,
+    GraphExecutionResult,
+    KernelRuntime,
+    RuntimeEvent,
+    RuntimeExecutionResult,
+    RuntimeState,
+    TaskGraph,
+    TaskNode,
+)
 
 # -----------------------------------------------------------------------------
 # Evidence surface (stable)
@@ -97,6 +111,18 @@ __all__ = [
     "DualChannelKernel",
     # Tooling
     "ToolRegistry",
+    "ExecutionContext",
+    "ExecutionIdentity",
+    "GraphBudget",
+    "ArtifactRef",
+    "Artifact",
+    "TaskNode",
+    "TaskGraph",
+    "GraphExecutionResult",
+    "RuntimeState",
+    "KernelRuntime",
+    "RuntimeEvent",
+    "RuntimeExecutionResult",
     # Evidence
     "AuditLedger",
     "replay_and_verify",

--- a/kernels/core/__init__.py
+++ b/kernels/core/__init__.py
@@ -1,0 +1,35 @@
+"""Core runtime primitives.
+
+This package contains the canonical runtime execution choke point used by
+kernel variants to mediate tool execution through a single interface.
+"""
+
+from kernels.core.runtime import (
+    Artifact,
+    ArtifactRef,
+    ExecutionIdentity,
+    ExecutionContext,
+    GraphBudget,
+    GraphExecutionResult,
+    RuntimeState,
+    TaskGraph,
+    TaskNode,
+    RuntimeEvent,
+    RuntimeExecutionResult,
+    KernelRuntime,
+)
+
+__all__ = [
+    "ExecutionContext",
+    "ExecutionIdentity",
+    "GraphBudget",
+    "ArtifactRef",
+    "Artifact",
+    "TaskNode",
+    "TaskGraph",
+    "GraphExecutionResult",
+    "RuntimeState",
+    "RuntimeEvent",
+    "RuntimeExecutionResult",
+    "KernelRuntime",
+]

--- a/kernels/core/runtime.py
+++ b/kernels/core/runtime.py
@@ -1,0 +1,780 @@
+"""Kernel runtime execution choke point.
+
+All tool execution should pass through KernelRuntime.execute so policy, budget,
+and observability hooks can be applied consistently.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from time import perf_counter
+from typing import Callable, Optional
+
+from kernels.common.hashing import compute_hash_dict
+from kernels.common.types import ToolCall
+from kernels.execution.dispatcher import Dispatcher, ExecutionResult
+from kernels.memory.artifact_store import ArtifactStore
+from kernels.memory.idempotency_store import IdempotencyRecord, IdempotencyStore
+
+
+@dataclass(frozen=True)
+class ExecutionContext:
+    """Canonical execution context propagated across the runtime path."""
+
+    trace_id: str
+    actor: str
+    state_ref: str
+    policy_ref: str
+    execution_identity: Optional[str] = None
+    graph_id: Optional[str] = None
+    node_id: Optional[str] = None
+    strategy_snapshot: Optional[str] = None
+    budget_ref: Optional[str] = None
+    memory_ref: str = "memory:none"
+    artifact_refs: tuple[str, ...] = field(default_factory=tuple)
+    parent_event_id: Optional[str] = None
+    causal_chain: tuple[str, ...] = field(default_factory=tuple)
+    policy_snapshot: Optional[str] = None
+    idempotency_key: Optional[str] = None
+    max_time_ms: Optional[int] = None
+    max_calls: Optional[int] = None
+    call_index: int = 1
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RuntimeEvent:
+    """Structured runtime event emitted during execution."""
+
+    event_id: str
+    event_type: str
+    execution_identity: Optional[str]
+    trace_id: str
+    graph_id: Optional[str]
+    node_id: Optional[str]
+    parent_event_id: Optional[str]
+    ts_ms: int
+    payload: dict[str, str]
+
+
+@dataclass(frozen=True)
+class RuntimeExecutionResult:
+    """Runtime result with context and optional budget violation markers."""
+
+    dispatcher_result: ExecutionResult
+    trace_id: str
+    elapsed_ms: int
+    budget_exceeded: bool
+    denied_by_hook: bool = False
+    deduplicated: bool = False
+
+
+@dataclass(frozen=True)
+class ArtifactRef:
+    """Reference to an artifact consumed by a node."""
+
+    artifact_id: str
+    required_type: Optional[str] = None
+    required_schema_version: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class Artifact:
+    """Typed artifact produced by runtime execution."""
+
+    artifact_id: str
+    artifact_type: str
+    schema_version: str
+    value: object
+    value_hash: str
+    provenance: tuple[str, ...]
+    created_event_id: Optional[str] = None
+    parent_artifacts: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ExecutionIdentity:
+    """Unified identity across runtime, events, and cache keys."""
+
+    value: str
+    node_id: Optional[str]
+    graph_id: Optional[str]
+    tool_name: str
+
+
+@dataclass(frozen=True)
+class TaskNode:
+    """Single node in a deterministic execution graph."""
+
+    node_id: str
+    tool_call: ToolCall
+    depends_on: tuple[str, ...] = field(default_factory=tuple)
+    input_artifacts: tuple[ArtifactRef, ...] = field(default_factory=tuple)
+    output_artifact_type: str = "tool.result"
+    output_schema_version: str = "v1"
+
+
+@dataclass(frozen=True)
+class TaskGraph:
+    """Directed acyclic graph of runtime tasks."""
+
+    graph_id: str
+    nodes: tuple[TaskNode, ...]
+
+
+@dataclass(frozen=True)
+class GraphExecutionResult:
+    """Execution result for a task graph."""
+
+    trace_id: str
+    node_results: dict[str, RuntimeExecutionResult]
+    execution_order: tuple[str, ...]
+    output_artifacts: dict[str, Artifact]
+    success: bool
+    error: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class RuntimeState:
+    """Reduced runtime state reconstructed from runtime events."""
+
+    completed_nodes: frozenset[str] = frozenset()
+    failed_nodes: frozenset[str] = frozenset()
+    created_artifacts: frozenset[str] = frozenset()
+
+    @staticmethod
+    def reduce_events(events: list[RuntimeEvent]) -> "RuntimeState":
+        """Reconstruct a minimal state projection from runtime events."""
+        completed_nodes: set[str] = set()
+        failed_nodes: set[str] = set()
+        created_artifacts: set[str] = set()
+
+        for event in events:
+            node_id = event.node_id
+            if event.event_type == "node.completed" and node_id is not None:
+                completed_nodes.add(node_id)
+            elif event.event_type == "node.failed" and node_id is not None:
+                failed_nodes.add(node_id)
+            elif event.event_type == "artifact.created":
+                artifact_id = event.payload.get("artifact_id")
+                if artifact_id:
+                    created_artifacts.add(artifact_id)
+
+        return RuntimeState(
+            completed_nodes=frozenset(completed_nodes),
+            failed_nodes=frozenset(failed_nodes),
+            created_artifacts=frozenset(created_artifacts),
+        )
+
+
+@dataclass(frozen=True)
+class GraphBudget:
+    """Composable call budget for graph execution."""
+
+    total_calls: int
+    remaining_calls: int
+
+
+class KernelRuntime:
+    """Single kernel execution choke point.
+
+    This class wraps dispatcher execution so every call can consistently apply:
+    1) context propagation
+    2) pre/post execution hooks
+    3) execution-time budget checks
+    """
+
+    def __init__(
+        self,
+        dispatcher: Dispatcher,
+        before_execute: Optional[
+            Callable[[ExecutionContext, ToolCall], Optional[str]]
+        ] = None,
+        after_execute: Optional[
+            Callable[[ExecutionContext, ToolCall, RuntimeExecutionResult], None]
+        ] = None,
+        on_error: Optional[
+            Callable[[ExecutionContext, ToolCall, RuntimeExecutionResult], None]
+        ] = None,
+        event_sink: Optional[Callable[[RuntimeEvent], None]] = None,
+        now_ms: Optional[Callable[[], int]] = None,
+        artifact_store: Optional[ArtifactStore] = None,
+        idempotency_store: Optional[IdempotencyStore] = None,
+    ) -> None:
+        self._dispatcher = dispatcher
+        self._before_execute = before_execute
+        self._after_execute = after_execute
+        self._on_error = on_error
+        self._event_sink = event_sink
+        self._now_ms = now_ms or (lambda: 0)
+        self._result_cache: dict[str, RuntimeExecutionResult] = {}
+        self._artifact_store = artifact_store or ArtifactStore()
+        self._idempotency_store = idempotency_store or IdempotencyStore()
+
+    @property
+    def dispatcher(self) -> Dispatcher:
+        """Expose dispatcher for explicit tool registration."""
+        return self._dispatcher
+
+    def set_hooks(
+        self,
+        *,
+        before_execute: Optional[
+            Callable[[ExecutionContext, ToolCall], Optional[str]]
+        ] = None,
+        after_execute: Optional[
+            Callable[[ExecutionContext, ToolCall, RuntimeExecutionResult], None]
+        ] = None,
+        on_error: Optional[
+            Callable[[ExecutionContext, ToolCall, RuntimeExecutionResult], None]
+        ] = None,
+        event_sink: Optional[Callable[[RuntimeEvent], None]] = None,
+    ) -> None:
+        """Replace runtime hooks used for observability or policy injection."""
+        self._before_execute = before_execute
+        self._after_execute = after_execute
+        self._on_error = on_error
+        self._event_sink = event_sink
+
+    def _emit(
+        self,
+        event_type: str,
+        context: ExecutionContext,
+        payload: dict[str, str],
+    ) -> RuntimeEvent:
+        event = RuntimeEvent(
+            event_id=compute_hash_dict(
+                {
+                    "trace_id": context.trace_id,
+                    "event_type": event_type,
+                    "parent_event_id": context.parent_event_id,
+                    "call_index": context.call_index,
+                    "payload": payload,
+                    "ts_ms": self._now_ms(),
+                }
+            ),
+            event_type=event_type,
+            execution_identity=context.execution_identity,
+            trace_id=context.trace_id,
+            graph_id=context.graph_id,
+            node_id=context.node_id,
+            parent_event_id=context.parent_event_id,
+            ts_ms=self._now_ms(),
+            payload=payload,
+        )
+        if self._event_sink is not None:
+            self._event_sink(event)
+        return event
+
+    def _compute_idempotency_key(
+        self, context: ExecutionContext, tool_call: ToolCall
+    ) -> str:
+        if context.idempotency_key is not None:
+            return context.idempotency_key
+        return compute_hash_dict(
+            {
+                "execution_identity": context.execution_identity,
+                "actor": context.actor,
+                "graph_id": context.graph_id,
+                "node_id": context.node_id,
+                "artifact_refs": context.artifact_refs,
+                "tool_name": tool_call.name,
+                "params": tool_call.params,
+                "state_ref": context.state_ref,
+            }
+        )
+
+    def _build_execution_identity(
+        self,
+        *,
+        context: ExecutionContext,
+        tool_call: ToolCall,
+    ) -> ExecutionIdentity:
+        input_hashes = tuple(
+            sorted(
+                h for h in context.metadata.get("input_hashes", "").split(",") if h
+            )
+        )
+        value = compute_hash_dict(
+            {
+                "trace_id": context.trace_id,
+                "graph_id": context.graph_id,
+                "node_id": context.node_id,
+                "tool_name": tool_call.name,
+                "tool_params": tool_call.params,
+                "input_hashes": input_hashes,
+                "policy_snapshot": context.policy_snapshot,
+                "strategy_snapshot": context.strategy_snapshot,
+            }
+        )
+        return ExecutionIdentity(
+            value=value,
+            node_id=context.node_id,
+            graph_id=context.graph_id,
+            tool_name=tool_call.name,
+        )
+
+    def execute(
+        self,
+        tool_call: ToolCall,
+        context: ExecutionContext,
+    ) -> RuntimeExecutionResult:
+        """Execute a tool call through the canonical runtime boundary."""
+        execution_identity = self._build_execution_identity(
+            context=context,
+            tool_call=tool_call,
+        )
+        effective_context = ExecutionContext(
+            trace_id=context.trace_id,
+            execution_identity=execution_identity.value,
+            actor=context.actor,
+            state_ref=context.state_ref,
+            policy_ref=context.policy_ref,
+            graph_id=context.graph_id,
+            node_id=context.node_id,
+            strategy_snapshot=context.strategy_snapshot,
+            budget_ref=context.budget_ref,
+            memory_ref=context.memory_ref,
+            artifact_refs=context.artifact_refs,
+            parent_event_id=context.parent_event_id,
+            causal_chain=context.causal_chain,
+            policy_snapshot=context.policy_snapshot,
+            idempotency_key=context.idempotency_key,
+            max_time_ms=context.max_time_ms,
+            max_calls=context.max_calls,
+            call_index=context.call_index,
+            metadata=context.metadata,
+        )
+
+        self._emit(
+            "task.started",
+            effective_context,
+            {"tool_name": tool_call.name, "actor": context.actor},
+        )
+
+        if (
+            effective_context.max_calls is not None
+            and effective_context.call_index > effective_context.max_calls
+        ):
+            denied = RuntimeExecutionResult(
+                dispatcher_result=ExecutionResult(
+                    success=False,
+                    tool_name=tool_call.name,
+                    error=(
+                        f"Call budget exceeded: call_index={effective_context.call_index} > "
+                        f"max_calls={effective_context.max_calls}"
+                    ),
+                ),
+                trace_id=effective_context.trace_id,
+                elapsed_ms=0,
+                budget_exceeded=True,
+            )
+            self._emit(
+                "error.raised",
+                effective_context,
+                {"error": denied.dispatcher_result.error or "UNKNOWN"},
+            )
+            return denied
+
+        idempotency_key = self._compute_idempotency_key(effective_context, tool_call)
+        if idempotency_key in self._result_cache:
+            cached = self._result_cache[idempotency_key]
+            record = self._idempotency_store.get(idempotency_key)
+            replayed = RuntimeExecutionResult(
+                dispatcher_result=cached.dispatcher_result,
+                trace_id=effective_context.trace_id,
+                elapsed_ms=0,
+                budget_exceeded=cached.budget_exceeded,
+                denied_by_hook=cached.denied_by_hook,
+                deduplicated=True,
+            )
+            self._emit(
+                "tool.deduplicated",
+                effective_context,
+                {
+                    "tool_name": tool_call.name,
+                    "idempotency_key": idempotency_key,
+                    "output_hash": record.output_hash if record else "unknown",
+                },
+            )
+            return replayed
+
+        if self._before_execute is not None:
+            denial_reason = self._before_execute(effective_context, tool_call)
+            if denial_reason:
+                denied = RuntimeExecutionResult(
+                    dispatcher_result=ExecutionResult(
+                        success=False,
+                        tool_name=tool_call.name,
+                        error=f"Execution denied by hook: {denial_reason}",
+                    ),
+                    trace_id=effective_context.trace_id,
+                    elapsed_ms=0,
+                    budget_exceeded=False,
+                    denied_by_hook=True,
+                )
+                self._emit(
+                    "policy.denied",
+                    effective_context,
+                    {"reason": denial_reason},
+                )
+                if self._on_error is not None:
+                    self._on_error(effective_context, tool_call, denied)
+                return denied
+
+        self._emit("tool.called", effective_context, {"tool_name": tool_call.name})
+        start = perf_counter()
+        dispatcher_result = self._dispatcher.execute(tool_call)
+        elapsed_ms = int((perf_counter() - start) * 1000)
+
+        budget_exceeded = (
+            effective_context.max_time_ms is not None
+            and elapsed_ms > effective_context.max_time_ms
+        )
+        if budget_exceeded and dispatcher_result.success:
+            dispatcher_result = ExecutionResult(
+                success=False,
+                tool_name=tool_call.name,
+                error=(
+                    f"Execution budget exceeded: {elapsed_ms}ms > "
+                    f"{effective_context.max_time_ms}ms"
+                ),
+            )
+
+        result = RuntimeExecutionResult(
+            dispatcher_result=dispatcher_result,
+            trace_id=effective_context.trace_id,
+            elapsed_ms=elapsed_ms,
+            budget_exceeded=budget_exceeded,
+        )
+        if result.dispatcher_result.success:
+            self._result_cache[idempotency_key] = result
+            self._idempotency_store.put(
+                IdempotencyRecord(
+                    key=idempotency_key,
+                    input_hash=compute_hash_dict(
+                        {
+                            "tool_name": tool_call.name,
+                            "tool_params": tool_call.params,
+                            "execution_identity": effective_context.execution_identity,
+                        }
+                    ),
+                    output_hash=compute_hash_dict(
+                        {"result": result.dispatcher_result.result}
+                    ),
+                    tool_name=tool_call.name,
+                    ts_ms=self._now_ms(),
+                )
+            )
+            self._emit(
+                "tool.completed",
+                effective_context,
+                {"tool_name": tool_call.name},
+            )
+            self._emit(
+                "task.completed",
+                effective_context,
+                {"tool_name": tool_call.name},
+            )
+        else:
+            self._emit(
+                "error.raised",
+                effective_context,
+                {"error": result.dispatcher_result.error or "UNKNOWN"},
+            )
+            if self._on_error is not None:
+                self._on_error(effective_context, tool_call, result)
+
+        if self._after_execute is not None:
+            self._after_execute(effective_context, tool_call, result)
+
+        return result
+
+    def _resolve_execution_order(self, graph: TaskGraph) -> tuple[str, ...]:
+        """Resolve deterministic topological order for graph nodes."""
+        nodes_by_id = {node.node_id: node for node in graph.nodes}
+        if len(nodes_by_id) != len(graph.nodes):
+            raise ValueError("Graph contains duplicate node IDs")
+
+        for node in graph.nodes:
+            for dependency_id in node.depends_on:
+                if dependency_id not in nodes_by_id:
+                    raise ValueError(
+                        f"Graph node '{node.node_id}' depends on unknown node "
+                        f"'{dependency_id}'"
+                    )
+
+        visited: set[str] = set()
+        visiting: set[str] = set()
+        order: list[str] = []
+
+        def visit(node_id: str) -> None:
+            if node_id in visited:
+                return
+            if node_id in visiting:
+                raise ValueError(f"Graph cycle detected at node '{node_id}'")
+
+            visiting.add(node_id)
+            node = nodes_by_id[node_id]
+            for dep_id in sorted(node.depends_on):
+                visit(dep_id)
+            visiting.remove(node_id)
+            visited.add(node_id)
+            order.append(node_id)
+
+        for node_id in sorted(nodes_by_id.keys()):
+            visit(node_id)
+
+        return tuple(order)
+
+    def execute_graph(
+        self, graph: TaskGraph, context: ExecutionContext
+    ) -> GraphExecutionResult:
+        """Execute a deterministic DAG of tool calls."""
+        self._emit(
+            "graph.started",
+            context,
+            {"graph_id": graph.graph_id, "node_count": str(len(graph.nodes))},
+        )
+        nodes_by_id = {node.node_id: node for node in graph.nodes}
+        order = self._resolve_execution_order(graph)
+        budget = GraphBudget(
+            total_calls=context.max_calls if context.max_calls is not None else len(order),
+            remaining_calls=context.max_calls
+            if context.max_calls is not None
+            else len(order),
+        )
+        results: dict[str, RuntimeExecutionResult] = {}
+        produced_artifacts: dict[str, Artifact] = {}
+        produced_by_node: dict[str, str] = {}
+
+        for index, node_id in enumerate(order, start=1):
+            node = nodes_by_id[node_id]
+            if budget.remaining_calls <= 0:
+                self._emit(
+                    "graph.failed",
+                    context,
+                    {
+                        "graph_id": graph.graph_id,
+                        "failed_node": node_id,
+                        "error": "Graph call budget exhausted",
+                    },
+                )
+                return GraphExecutionResult(
+                    trace_id=context.trace_id,
+                    node_results=results,
+                    execution_order=tuple(results.keys()),
+                    output_artifacts=produced_artifacts,
+                    success=False,
+                    error="Graph call budget exhausted",
+                )
+            self._emit(
+                "node.scheduled",
+                context,
+                {"graph_id": graph.graph_id, "node_id": node_id},
+            )
+            parent_event_id = None
+            if node.depends_on:
+                parent_event_id = compute_hash_dict(
+                    {
+                        "trace_id": context.trace_id,
+                        "graph_id": graph.graph_id,
+                        "node": sorted(node.depends_on),
+                    }
+                )
+
+            input_artifact_ids: list[str] = []
+            input_hashes: list[str] = []
+            for artifact_ref in node.input_artifacts:
+                artifact_lookup_id = artifact_ref.artifact_id
+                if artifact_lookup_id.startswith("node:"):
+                    source_node_id = artifact_lookup_id.split(":", 1)[1]
+                    artifact_lookup_id = produced_by_node.get(source_node_id, "")
+
+                artifact = self._artifact_store.get(artifact_lookup_id)
+                if artifact is None:
+                    self._emit(
+                        "node.failed",
+                        context,
+                        {
+                            "graph_id": graph.graph_id,
+                            "node_id": node_id,
+                            "error": (
+                                f"Missing input artifact: "
+                                f"{artifact_ref.artifact_id}"
+                            ),
+                        },
+                    )
+                    return GraphExecutionResult(
+                        trace_id=context.trace_id,
+                        node_results=results,
+                        execution_order=tuple(results.keys()),
+                        output_artifacts=produced_artifacts,
+                        success=False,
+                        error=f"Missing input artifact: {artifact_ref.artifact_id}",
+                    )
+                if (
+                    artifact_ref.required_type is not None
+                    and artifact.artifact_type != artifact_ref.required_type
+                ):
+                    self._emit(
+                        "node.failed",
+                        context,
+                        {
+                            "graph_id": graph.graph_id,
+                            "node_id": node_id,
+                            "error": (
+                                "Artifact type mismatch for "
+                                f"{artifact_ref.artifact_id}"
+                            ),
+                        },
+                    )
+                    return GraphExecutionResult(
+                        trace_id=context.trace_id,
+                        node_results=results,
+                        execution_order=tuple(results.keys()),
+                        output_artifacts=produced_artifacts,
+                        success=False,
+                        error=(
+                            "Artifact type mismatch for "
+                            f"{artifact_ref.artifact_id}"
+                        ),
+                    )
+                if (
+                    artifact_ref.required_schema_version is not None
+                    and artifact.schema_version
+                    != artifact_ref.required_schema_version
+                ):
+                    self._emit(
+                        "node.failed",
+                        context,
+                        {
+                            "graph_id": graph.graph_id,
+                            "node_id": node_id,
+                            "error": (
+                                "Artifact schema mismatch for "
+                                f"{artifact_ref.artifact_id}"
+                            ),
+                        },
+                    )
+                    return GraphExecutionResult(
+                        trace_id=context.trace_id,
+                        node_results=results,
+                        execution_order=tuple(results.keys()),
+                        output_artifacts=produced_artifacts,
+                        success=False,
+                        error=(
+                            "Artifact schema mismatch for "
+                            f"{artifact_ref.artifact_id}"
+                        ),
+                    )
+                input_artifact_ids.append(artifact.artifact_id)
+                input_hashes.append(artifact.value_hash)
+
+            self._emit(
+                "node.started",
+                context,
+                {"graph_id": graph.graph_id, "node_id": node_id},
+            )
+            node_context = ExecutionContext(
+                trace_id=context.trace_id,
+                execution_identity=None,
+                graph_id=graph.graph_id,
+                node_id=node_id,
+                actor=context.actor,
+                state_ref=context.state_ref,
+                policy_ref=context.policy_ref,
+                strategy_snapshot=context.strategy_snapshot,
+                budget_ref=context.budget_ref,
+                memory_ref=context.memory_ref,
+                artifact_refs=tuple(sorted(input_artifact_ids)),
+                parent_event_id=parent_event_id,
+                causal_chain=context.causal_chain + (node_id,),
+                policy_snapshot=context.policy_snapshot,
+                idempotency_key=None,
+                max_time_ms=context.max_time_ms,
+                max_calls=context.max_calls,
+                call_index=index,
+                metadata={
+                    **context.metadata,
+                    "input_hashes": ",".join(sorted(input_hashes)),
+                    "budget_remaining_calls": str(budget.remaining_calls),
+                },
+            )
+
+            node_result = self.execute(node.tool_call, node_context)
+            results[node_id] = node_result
+            budget = GraphBudget(
+                total_calls=budget.total_calls,
+                remaining_calls=max(0, budget.remaining_calls - 1),
+            )
+            if not node_result.dispatcher_result.success:
+                self._emit(
+                    "graph.failed",
+                    context,
+                    {
+                        "graph_id": graph.graph_id,
+                        "failed_node": node_id,
+                        "error": node_result.dispatcher_result.error or "UNKNOWN",
+                    },
+                )
+                return GraphExecutionResult(
+                    trace_id=context.trace_id,
+                    node_results=results,
+                    execution_order=tuple(results.keys()),
+                    output_artifacts=produced_artifacts,
+                    success=False,
+                    error=node_result.dispatcher_result.error,
+                )
+            self._emit(
+                "node.completed",
+                context,
+                {"graph_id": graph.graph_id, "node_id": node_id},
+            )
+            artifact_event = self._emit(
+                "artifact.created",
+                node_context,
+                {"graph_id": graph.graph_id, "node_id": node_id},
+            )
+            stored_artifact = self._artifact_store.put(
+                artifact_id=None,
+                artifact_type=node.output_artifact_type,
+                schema_version=node.output_schema_version,
+                value=node_result.dispatcher_result.result,
+                provenance=(graph.graph_id, node_id),
+                created_event_id=artifact_event.event_id,
+                parent_artifacts=tuple(sorted(input_artifact_ids)),
+            )
+            produced_artifacts[stored_artifact.artifact_id] = Artifact(
+                artifact_id=stored_artifact.artifact_id,
+                artifact_type=stored_artifact.artifact_type,
+                schema_version=stored_artifact.schema_version,
+                value=stored_artifact.value,
+                value_hash=stored_artifact.value_hash,
+                provenance=stored_artifact.provenance,
+                created_event_id=stored_artifact.created_event_id,
+                parent_artifacts=stored_artifact.parent_artifacts,
+            )
+            produced_by_node[node_id] = stored_artifact.artifact_id
+            self._emit(
+                "dependency.resolved",
+                context,
+                {
+                    "graph_id": graph.graph_id,
+                    "node_id": node_id,
+                    "artifact_id": stored_artifact.artifact_id,
+                },
+            )
+
+        self._emit(
+            "graph.completed",
+            context,
+            {"graph_id": graph.graph_id, "node_count": str(len(order))},
+        )
+        return GraphExecutionResult(
+            trace_id=context.trace_id,
+            node_results=results,
+            execution_order=order,
+            output_artifacts=produced_artifacts,
+            success=True,
+        )

--- a/kernels/memory/__init__.py
+++ b/kernels/memory/__init__.py
@@ -1,0 +1,6 @@
+"""Memory primitives for runtime artifact persistence."""
+
+from kernels.memory.artifact_store import ArtifactStore
+from kernels.memory.idempotency_store import IdempotencyRecord, IdempotencyStore
+
+__all__ = ["ArtifactStore", "IdempotencyRecord", "IdempotencyStore"]

--- a/kernels/memory/artifact_store.py
+++ b/kernels/memory/artifact_store.py
@@ -1,0 +1,82 @@
+"""In-memory artifact store for deterministic runtime dataflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from kernels.common.hashing import compute_hash_dict
+
+
+@dataclass(frozen=True)
+class StoredArtifact:
+    """Persisted artifact entry."""
+
+    artifact_id: str
+    artifact_type: str
+    schema_version: str
+    value: Any
+    value_hash: str
+    provenance: tuple[str, ...]
+    created_event_id: Optional[str] = None
+    parent_artifacts: tuple[str, ...] = ()
+
+
+class ArtifactStore:
+    """Simple in-memory artifact store.
+
+    This store is deterministic and keyed by explicit artifact IDs.
+    """
+
+    def __init__(self) -> None:
+        self._artifacts: dict[str, StoredArtifact] = {}
+
+    def put(
+        self,
+        *,
+        artifact_id: Optional[str] = None,
+        artifact_type: str,
+        schema_version: str,
+        value: Any,
+        provenance: tuple[str, ...],
+        created_event_id: Optional[str] = None,
+        parent_artifacts: tuple[str, ...] = (),
+    ) -> StoredArtifact:
+        """Store an artifact and return the normalized record."""
+        value_hash = compute_hash_dict(
+            {
+                "artifact_type": artifact_type,
+                "schema_version": schema_version,
+                "value": value,
+                "provenance": provenance,
+                "parent_artifacts": parent_artifacts,
+            }
+        )
+        normalized_artifact_id = artifact_id or value_hash
+        if artifact_id is not None and artifact_id != value_hash:
+            raise ValueError("artifact_id must equal content hash for immutability")
+
+        existing = self._artifacts.get(normalized_artifact_id)
+        if existing is not None and existing.value_hash != value_hash:
+            raise ValueError("artifact_id collision with different content hash")
+
+        stored = StoredArtifact(
+            artifact_id=normalized_artifact_id,
+            artifact_type=artifact_type,
+            schema_version=schema_version,
+            value=value,
+            value_hash=value_hash,
+            provenance=provenance,
+            created_event_id=created_event_id,
+            parent_artifacts=parent_artifacts,
+        )
+        self._artifacts[normalized_artifact_id] = stored
+        return stored
+
+    def get(self, artifact_id: str) -> Optional[StoredArtifact]:
+        """Get an artifact by ID."""
+        return self._artifacts.get(artifact_id)
+
+    def has(self, artifact_id: str) -> bool:
+        """Check artifact presence."""
+        return artifact_id in self._artifacts

--- a/kernels/memory/idempotency_store.py
+++ b/kernels/memory/idempotency_store.py
@@ -1,0 +1,32 @@
+"""In-memory idempotency record store."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class IdempotencyRecord:
+    """Stored idempotency execution record."""
+
+    key: str
+    input_hash: str
+    output_hash: str
+    tool_name: str
+    ts_ms: int
+
+
+class IdempotencyStore:
+    """Record store for execution idempotency tracking."""
+
+    def __init__(self) -> None:
+        self._records: dict[str, IdempotencyRecord] = {}
+
+    def put(self, record: IdempotencyRecord) -> None:
+        """Store an idempotency record."""
+        self._records[record.key] = record
+
+    def get(self, key: str) -> Optional[IdempotencyRecord]:
+        """Get record by key."""
+        return self._records.get(key)

--- a/kernels/variants/base.py
+++ b/kernels/variants/base.py
@@ -5,7 +5,7 @@ provides common functionality that variants can extend.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from kernels.common.types import (
     Decision,
@@ -29,6 +29,12 @@ from kernels.jurisdiction.rules import evaluate_policy
 from kernels.state.machine import StateMachine
 from kernels.execution.tools import create_default_registry
 from kernels.execution.dispatcher import Dispatcher
+from kernels.core.runtime import (
+    ExecutionContext,
+    KernelRuntime,
+    RuntimeEvent,
+    RuntimeExecutionResult,
+)
 from kernels.permits import (
     NonceRegistry,
     PermitToken,
@@ -71,7 +77,8 @@ class Kernel(ABC):
 
         Args:
             request: Request to process.
-            permit_token: Permit token authorizing this request (required for execution in most variants).
+            permit_token: Permit token authorizing this request
+                (required for execution in most variants).
 
         Returns:
             Receipt with processing result.
@@ -122,6 +129,7 @@ class BaseKernel(Kernel):
         self._ledger: Optional[AuditLedger] = None
         self._policy: Optional[JurisdictionPolicy] = None
         self._dispatcher: Optional[Dispatcher] = None
+        self._runtime: Optional[KernelRuntime] = None
         self._pending_request: Optional[KernelRequest] = None
         self._pending_decision: Optional[Decision] = None
         self._pending_result: Optional[Any] = None
@@ -220,6 +228,10 @@ class BaseKernel(Kernel):
         self._ledger = AuditLedger(config.kernel_id, config.variant)
         self._policy = self._policy or JurisdictionPolicy.default()
         self._dispatcher = Dispatcher(create_default_registry())
+        self._runtime = KernelRuntime(
+            self._dispatcher,
+            now_ms=self._config.clock.now_ms,
+        )
 
         # Transition to IDLE
         self._state_machine.transition(KernelState.IDLE)
@@ -236,7 +248,7 @@ class BaseKernel(Kernel):
         """Submit a request for processing."""
         if self._state_machine is None:
             raise StateError("Kernel not booted")
-        if self._dispatcher is None or self._ledger is None:
+        if self._dispatcher is None or self._ledger is None or self._runtime is None:
             raise StateError("Kernel not booted")
 
         self._state_machine.assert_not_halted()
@@ -384,20 +396,43 @@ class BaseKernel(Kernel):
                     return self._fail_request(
                         request,
                         state_from,
-                        f"TOCTOU detected: tool_name mismatch (envelope: {decision_envelope.tool_name}, request: {request.tool_call.name})",
+                        (
+                            "TOCTOU detected: tool_name mismatch "
+                            f"(envelope: {decision_envelope.tool_name}, "
+                            f"request: {request.tool_call.name})"
+                        ),
                     )
                 # Params may have been normalized, so we don't do strict equality check
-                # The envelope proves what was verified; the params hash in audit proves what was executed
+                # The envelope proves what was verified.
+                # The params hash in audit proves what was executed.
 
             self._state_machine.transition(KernelState.EXECUTING)
-            exec_result = self._dispatcher.execute(request.tool_call)
-            if not exec_result.success:
+            context = ExecutionContext(
+                trace_id=request.request_id,
+                actor=request.actor,
+                state_ref=self._state_machine.state.value,
+                policy_ref="jurisdiction:active",
+                policy_snapshot=(
+                    f"actors={sorted(self.policy.allowed_actors)};"
+                    f"tools={sorted(self.policy.allowed_tools)}"
+                ),
+                idempotency_key=request.request_id,
+                max_time_ms=(
+                    decision_envelope.max_time_ms
+                    if decision_envelope is not None
+                    else None
+                ),
+                max_calls=1,
+                call_index=1,
+            )
+            runtime_result = self._runtime.execute(request.tool_call, context)
+            if not runtime_result.dispatcher_result.success:
                 return self._fail_request(
                     request,
                     state_from,
-                    f"Tool execution failed: {exec_result.error}",
+                    f"Tool execution failed: {runtime_result.dispatcher_result.error}",
                 )
-            tool_result = exec_result.result
+            tool_result = runtime_result.dispatcher_result.result
 
         # Audit
         self._state_machine.transition(KernelState.AUDITING)
@@ -650,4 +685,28 @@ class BaseKernel(Kernel):
             decision=Decision.DENY,
             error=error,
             evidence_hash=entry.entry_hash,
+        )
+
+    def set_runtime_hooks(
+        self,
+        *,
+        before_execute: Optional[
+            Callable[[ExecutionContext, ToolCall], Optional[str]]
+        ] = None,
+        after_execute: Optional[
+            Callable[[ExecutionContext, ToolCall, RuntimeExecutionResult], None]
+        ] = None,
+        on_error: Optional[
+            Callable[[ExecutionContext, ToolCall, RuntimeExecutionResult], None]
+        ] = None,
+        event_sink: Optional[Callable[[RuntimeEvent], None]] = None,
+    ) -> None:
+        """Configure runtime hooks for execution mediation observability."""
+        if self._runtime is None:
+            raise StateError("Kernel not booted")
+        self._runtime.set_hooks(
+            before_execute=before_execute,
+            after_execute=after_execute,
+            on_error=on_error,
+            event_sink=event_sink,
         )

--- a/tests/test_runtime_core.py
+++ b/tests/test_runtime_core.py
@@ -1,0 +1,320 @@
+"""Tests for runtime choke-point behavior."""
+
+import unittest
+
+from kernels.common.types import KernelConfig, KernelRequest, ReceiptStatus, ToolCall, VirtualClock
+from kernels.core.runtime import (
+    ArtifactRef,
+    ExecutionContext,
+    KernelRuntime,
+    TaskGraph,
+    TaskNode,
+)
+from kernels.execution.dispatcher import Dispatcher
+from kernels.execution.tools import create_default_registry
+from kernels.memory.artifact_store import ArtifactStore
+from kernels.permits import PermitBuilder
+from kernels.variants.strict_kernel import StrictKernel
+
+
+class TestKernelRuntimeHooks(unittest.TestCase):
+    """Ensure all execution flows through KernelRuntime hooks."""
+
+    def setUp(self) -> None:
+        self.clock = VirtualClock(initial_ms=1000)
+        self.config = KernelConfig(kernel_id="runtime-test", variant="strict", clock=self.clock)
+        self.kernel = StrictKernel()
+        self.kernel.boot(self.config)
+
+        self.key = b"test-secret-key-32-bytes-long123"
+        self.keyring = {"key1": self.key}
+        self.kernel.set_keyring(self.keyring)
+
+    def _permit(self, *, constraints: dict[str, object], max_executions: int = 1):
+        return (
+            PermitBuilder()
+            .issuer("operator1")
+            .subject("agent1")
+            .jurisdiction("default")
+            .action("echo")
+            .params({"text": "hello"})
+            .constraints(constraints)
+            .max_executions(max_executions)
+            .valid_from_ms(0)
+            .valid_until_ms(10000)
+            .evidence_hash("evidence")
+            .proposal_hash("proposal")
+            .build(self.keyring, "key1")
+        )
+
+    def test_runtime_hooks_receive_execution_context(self) -> None:
+        calls: list[tuple[str, str]] = []
+
+        def before(context, tool_call):
+            calls.append(("before", f"{context.trace_id}:{tool_call.name}"))
+
+        def after(context, tool_call, result):
+            tag = "ok" if result.dispatcher_result.success else "fail"
+            calls.append(("after", f"{context.trace_id}:{tool_call.name}:{tag}"))
+
+        self.kernel.set_runtime_hooks(before_execute=before, after_execute=after)
+
+        request = KernelRequest(
+            request_id="req-runtime-1",
+            ts_ms=1000,
+            actor="agent1",
+            intent="Echo hello",
+            tool_call=ToolCall(name="echo", params={"text": "hello"}),
+            params={"text": "hello"},
+        )
+
+        receipt = self.kernel.submit(request, permit_token=self._permit(constraints={}))
+
+        self.assertEqual(receipt.status, ReceiptStatus.ACCEPTED)
+        self.assertEqual(
+            calls,
+            [
+                ("before", "req-runtime-1:echo"),
+                ("after", "req-runtime-1:echo:ok"),
+            ],
+        )
+
+    def test_runtime_budget_violation_fails_execution(self) -> None:
+        request = KernelRequest(
+            request_id="req-runtime-2",
+            ts_ms=1000,
+            actor="agent1",
+            intent="Echo hello",
+            tool_call=ToolCall(name="echo", params={"text": "hello"}),
+            params={"text": "hello"},
+        )
+
+        permit = self._permit(constraints={"max_time_ms": -1})
+        receipt = self.kernel.submit(request, permit_token=permit)
+
+        self.assertEqual(receipt.status, ReceiptStatus.FAILED)
+        self.assertIsNotNone(receipt.error)
+        self.assertIn("Execution budget exceeded", receipt.error)
+
+    def test_before_hook_can_deny_execution(self) -> None:
+        request = KernelRequest(
+            request_id="req-runtime-3",
+            ts_ms=1000,
+            actor="agent1",
+            intent="Echo hello",
+            tool_call=ToolCall(name="echo", params={"text": "hello"}),
+            params={"text": "hello"},
+        )
+
+        def before(_context, _tool_call):
+            return "blocked-by-policy"
+
+        self.kernel.set_runtime_hooks(before_execute=before)
+        receipt = self.kernel.submit(request, permit_token=self._permit(constraints={}))
+
+        self.assertEqual(receipt.status, ReceiptStatus.FAILED)
+        self.assertIsNotNone(receipt.error)
+        self.assertIn("Execution denied by hook", receipt.error)
+
+    def test_runtime_emits_events_and_deduplicates(self) -> None:
+        events: list[str] = []
+
+        def sink(event):
+            events.append(event.event_type)
+
+        self.kernel.set_runtime_hooks(event_sink=sink)
+        permit = self._permit(constraints={}, max_executions=2)
+        request = KernelRequest(
+            request_id="req-runtime-4",
+            ts_ms=1000,
+            actor="agent1",
+            intent="Echo hello",
+            tool_call=ToolCall(name="echo", params={"text": "hello"}),
+            params={"text": "hello"},
+        )
+
+        receipt_1 = self.kernel.submit(request, permit_token=permit)
+        receipt_2 = self.kernel.submit(request, permit_token=permit)
+
+        self.assertEqual(receipt_1.status, ReceiptStatus.ACCEPTED)
+        self.assertEqual(receipt_2.status, ReceiptStatus.ACCEPTED)
+        self.assertIn("task.started", events)
+        self.assertIn("tool.called", events)
+        self.assertIn("tool.completed", events)
+        self.assertIn("tool.deduplicated", events)
+
+
+class TestKernelRuntimeGraphExecution(unittest.TestCase):
+    """Validate deterministic graph execution semantics."""
+
+    def setUp(self) -> None:
+        self.runtime = KernelRuntime(
+            Dispatcher(create_default_registry()),
+            now_ms=lambda: 1000,
+        )
+        self.context = ExecutionContext(
+            trace_id="trace-graph-1",
+            actor="agent1",
+            state_ref="EXECUTING",
+            policy_ref="jurisdiction:active",
+            idempotency_key="trace-graph-1",
+            max_calls=10,
+        )
+
+    def test_execute_graph_orders_nodes_deterministically(self) -> None:
+        graph = TaskGraph(
+            graph_id="graph-1",
+            nodes=(
+                TaskNode(
+                    node_id="b",
+                    tool_call=ToolCall(name="echo", params={"text": "b"}),
+                    depends_on=("a",),
+                ),
+                TaskNode(
+                    node_id="a",
+                    tool_call=ToolCall(name="echo", params={"text": "a"}),
+                ),
+                TaskNode(
+                    node_id="c",
+                    tool_call=ToolCall(name="echo", params={"text": "c"}),
+                    depends_on=("b",),
+                    input_artifacts=(
+                        ArtifactRef(
+                            artifact_id="node:b",
+                            required_type="tool.result",
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        result = self.runtime.execute_graph(graph, self.context)
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.execution_order, ("a", "b", "c"))
+        self.assertEqual(
+            result.node_results["a"].dispatcher_result.result,
+            "a",
+        )
+        self.assertEqual(
+            result.node_results["b"].dispatcher_result.result,
+            "b",
+        )
+        self.assertEqual(
+            result.node_results["c"].dispatcher_result.result,
+            "c",
+        )
+        self.assertEqual(len(result.output_artifacts), 3)
+
+    def test_execute_graph_detects_cycles(self) -> None:
+        graph = TaskGraph(
+            graph_id="graph-cycle",
+            nodes=(
+                TaskNode(
+                    node_id="a",
+                    tool_call=ToolCall(name="echo", params={"text": "a"}),
+                    depends_on=("b",),
+                ),
+                TaskNode(
+                    node_id="b",
+                    tool_call=ToolCall(name="echo", params={"text": "b"}),
+                    depends_on=("a",),
+                ),
+            ),
+        )
+
+        with self.assertRaises(ValueError):
+            self.runtime.execute_graph(graph, self.context)
+
+    def test_execute_graph_fails_on_missing_input_artifact(self) -> None:
+        graph = TaskGraph(
+            graph_id="graph-missing-artifact",
+            nodes=(
+                TaskNode(
+                    node_id="a",
+                    tool_call=ToolCall(name="echo", params={"text": "a"}),
+                    input_artifacts=(
+                        ArtifactRef(artifact_id="missing", required_type="tool.result"),
+                    ),
+                ),
+            ),
+        )
+
+        result = self.runtime.execute_graph(graph, self.context)
+        self.assertFalse(result.success)
+        self.assertIsNotNone(result.error)
+        self.assertIn("Missing input artifact", result.error)
+
+    def test_execute_graph_fails_on_schema_mismatch(self) -> None:
+        graph = TaskGraph(
+            graph_id="graph-schema-mismatch",
+            nodes=(
+                TaskNode(
+                    node_id="a",
+                    tool_call=ToolCall(name="echo", params={"text": "a"}),
+                ),
+                TaskNode(
+                    node_id="b",
+                    tool_call=ToolCall(name="echo", params={"text": "b"}),
+                    input_artifacts=(
+                        ArtifactRef(
+                            artifact_id="node:a",
+                            required_type="tool.result",
+                            required_schema_version="v2",
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        result = self.runtime.execute_graph(graph, self.context)
+        self.assertFalse(result.success)
+        self.assertIsNotNone(result.error)
+        self.assertIn("schema mismatch", result.error)
+
+    def test_execute_graph_fails_when_budget_exhausted(self) -> None:
+        budgeted_context = ExecutionContext(
+            trace_id="trace-budget",
+            actor="agent1",
+            state_ref="EXECUTING",
+            policy_ref="jurisdiction:active",
+            max_calls=1,
+        )
+        graph = TaskGraph(
+            graph_id="graph-budget",
+            nodes=(
+                TaskNode(
+                    node_id="a",
+                    tool_call=ToolCall(name="echo", params={"text": "a"}),
+                ),
+                TaskNode(
+                    node_id="b",
+                    tool_call=ToolCall(name="echo", params={"text": "b"}),
+                    depends_on=("a",),
+                ),
+            ),
+        )
+
+        result = self.runtime.execute_graph(graph, budgeted_context)
+        self.assertFalse(result.success)
+        self.assertEqual(result.execution_order, ("a",))
+        self.assertEqual(result.error, "Graph call budget exhausted")
+
+
+class TestArtifactStoreInvariants(unittest.TestCase):
+    """Validate immutability and content-addressing invariants."""
+
+    def test_artifact_store_rejects_non_content_address_id(self) -> None:
+        store = ArtifactStore()
+        with self.assertRaises(ValueError):
+            store.put(
+                artifact_id="manual-id",
+                artifact_type="tool.result",
+                schema_version="v1",
+                value={"x": 1},
+                provenance=("g1", "n1"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Establish a single runtime execution choke point so policy, budgeting, and observability are applied consistently to all tool calls.
- Provide deterministic memory and idempotency primitives to support content-addressed artifacts and replayability.
- Offer a deterministic task-graph execution model with budget enforcement and typed runtime events to improve auditability and variant isolation.

### Description

- Add a new runtime module `kernels/core/runtime.py` implementing `KernelRuntime`, `ExecutionContext`, `RuntimeEvent`, graph/task types (`TaskGraph`, `TaskNode`), idempotency, event emission, and `execute_graph` semantics.
- Add in-memory memory primitives in `kernels/memory/` with `ArtifactStore` and `IdempotencyStore` and export them via `kernels/memory.__init__`.
- Wire the runtime into the base kernel by initializing `KernelRuntime` in `BaseKernel.boot`, replacing direct dispatcher calls with `KernelRuntime.execute`, and adding `set_runtime_hooks` to configure before/after/on_error hooks and event sinks. 
- Surface runtime types in the public API via `kernels/api.py` and add `kernels/core.__init__` and documentation `docs/architecture/KERNEL_STRATA.md` plus update `docs/README.md`.
- Add comprehensive unit tests in `tests/test_runtime_core.py` exercising hooks, budget denial, deduplication/events, graph ordering/cycle detection/missing-artifact/schema-mismatch, and artifact store invariants.

### Testing

- Ran the new unit test module `tests/test_runtime_core.py` which exercises runtime hooks, budget failure, hook-based denial, event emission/deduplication, graph execution semantics, and artifact store invariants, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac03ebdbc8326a9206ce2760c81dd)